### PR TITLE
화면 구현 : 챌린지 플레이, 게임 플레이

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -9,9 +9,9 @@ import GamePlayView from '@/views/GamePlayView.vue';
 import LoadingScreen from '@/components/LoadingScreen.vue';
 import FailScreen from '@/components/FailScreen.vue';
 import SuccessScreen from '@/components/SuccessScreen.vue';
+import ChallengePlayView from '@/views/ChallengePlayView.vue';
 
 const routes = [
-
   {
     // path: '/',
     path: '/home-view',
@@ -65,6 +65,12 @@ const routes = [
     path: '/game-play-view',
     name: 'GamePlayView',
     component: GamePlayView,
+  },
+  {
+    path: '/',
+    // path: '/challenge-play-view',
+    name: 'ChallengePlayView',
+    component: ChallengePlayView,
   },
 ];
 

--- a/src/utils/teachableMachineForChallenge.js
+++ b/src/utils/teachableMachineForChallenge.js
@@ -9,15 +9,13 @@ async function init() {
     const modelURL = URL + "model.json";
     const metadataURL = URL + "metadata.json";
 
-    // 모델 로드
     model = await tmImage.load(modelURL, metadataURL);
     maxPredictions = model.getTotalClasses();
 
     const flip = true;
-    // 웹캠을 전체 화면으로 설정
     webcam = new tmImage.Webcam(window.innerWidth, window.innerHeight, flip);
     try {
-        await webcam.setup(); // 웹캠 접근 허용 요청
+        await webcam.setup();
         await webcam.play();
         document.getElementById("webcam-container").appendChild(webcam.canvas);
         webcam.canvas.style.width = '100%'
@@ -26,13 +24,11 @@ async function init() {
         console.error("웹캠 설정 실패: ", error);
     }
 
-    window.requestAnimationFrame(loop); // 루프 시작
+    window.requestAnimationFrame(loop);
 
-
-    // 예측 결과 표시할 공간
     labelContainer = document.getElementById("label-container");
     if (labelContainer) {
-        labelContainer.innerHTML = ""; // label-container 비우기
+        labelContainer.innerHTML = "";
         for (let i = 0; i < maxPredictions; i++) {
             labelContainer.appendChild(document.createElement("div"));
         }
@@ -49,9 +45,8 @@ async function loop() {
 
 async function predict() {
     const prediction = await model.predict(webcam.canvas);
-    let currentLabel = ""; // 현재 상태
+    let currentLabel = "";
 
-    // 푸쉬업과 푸쉬다운 상태를 감지
     for (let i = 0; i < maxPredictions; i++) {
         const classPrediction = prediction[i].className + ": " + prediction[i].probability.toFixed(2);
         if (labelContainer && labelContainer.childNodes[i]) {
@@ -59,21 +54,20 @@ async function predict() {
         }
 
         if (prediction[i].probability.toFixed(2) > 0.7) {
-            currentLabel = prediction[i].className; // 확률이 70% 이상인 상태를 현재 상태로 설정
+            currentLabel = prediction[i].className;
         }
     }
 
-    // 상태 변화 감지 로직 (pushdown -> pushup)
     if (lastLabel === "pushdown" && currentLabel === "pushup") {
-        counter++; // 카운트 증가
+        counter++;
 
         const counterElement = document.getElementById("counter");
         if (counterElement) {
-            counterElement.innerText = counter; // 화면에 카운트 업데이트
+            counterElement.innerText = counter;
         }
     }
 
-    lastLabel = currentLabel; // 마지막 상태 업데이트
+    lastLabel = currentLabel;
 }
 
 export { getCounter, init };

--- a/src/utils/teachableMachineForGame.js
+++ b/src/utils/teachableMachineForGame.js
@@ -1,0 +1,66 @@
+const URL = '/model/';
+let model, webcam, labelContainer, maxPredictions, counter = 0, lastLabel = "";
+
+async function getCounter() {
+    return counter;
+}
+
+async function init() {
+    const modelURL = URL + "model.json";
+    const metadataURL = URL + "metadata.json";
+
+    // 모델 로드
+    model = await tmImage.load(modelURL, metadataURL);
+    maxPredictions = model.getTotalClasses();
+
+    const flip = true;
+    webcam = new tmImage.Webcam(400, 300, flip); // ver4: 웹캠 설정 (비율 4:3)
+    try {
+        await webcam.setup(); // 웹캠 접근 허용 요청
+        await webcam.play();
+        document.getElementById("webcam-container").appendChild(webcam.canvas);
+    } catch (error) {
+        console.error("웹캠 설정 실패: ", error);
+    }
+
+    window.requestAnimationFrame(loop); // 루프 시작
+
+    // 예측 결과 표시할 공간
+    labelContainer = document.getElementById("label-container");
+    labelContainer.innerHTML = ""; // label-container 비우기
+
+    for (let i = 0; i < maxPredictions; i++) {
+        labelContainer.appendChild(document.createElement("div"));
+    }
+}
+
+async function loop() {
+    webcam.update();
+    await predict();
+    window.requestAnimationFrame(loop);
+}
+
+async function predict() {
+    const prediction = await model.predict(webcam.canvas);
+    let currentLabel = ""; // 현재 상태
+
+    // 푸쉬업과 푸쉬다운 상태를 감지
+    for (let i = 0; i < maxPredictions; i++) {
+        const classPrediction = prediction[i].className + ": " + prediction[i].probability.toFixed(2);
+        labelContainer.childNodes[i].innerHTML = classPrediction;
+
+        if (prediction[i].probability.toFixed(2) > 0.7) {
+            currentLabel = prediction[i].className; // 확률이 70% 이상인 상태를 현재 상태로 설정
+        }
+    }
+
+    // 상태 변화 감지 로직 (pushdown -> pushup)
+    if (lastLabel === "pushdown" && currentLabel === "pushup") {
+        counter++; // 카운트 증가
+        document.getElementById("counter").innerText = counter; // 화면에 카운트 업데이트
+    }
+
+    lastLabel = currentLabel; // 마지막 상태 업데이트
+}
+
+export { getCounter, init };

--- a/src/utils/teachableMachineForGame.js
+++ b/src/utils/teachableMachineForGame.js
@@ -9,25 +9,23 @@ async function init() {
     const modelURL = URL + "model.json";
     const metadataURL = URL + "metadata.json";
 
-    // 모델 로드
     model = await tmImage.load(modelURL, metadataURL);
     maxPredictions = model.getTotalClasses();
 
     const flip = true;
-    webcam = new tmImage.Webcam(400, 300, flip); // ver4: 웹캠 설정 (비율 4:3)
+    webcam = new tmImage.Webcam(400, 300, flip);
     try {
-        await webcam.setup(); // 웹캠 접근 허용 요청
+        await webcam.setup();
         await webcam.play();
         document.getElementById("webcam-container").appendChild(webcam.canvas);
     } catch (error) {
         console.error("웹캠 설정 실패: ", error);
     }
 
-    window.requestAnimationFrame(loop); // 루프 시작
+    window.requestAnimationFrame(loop);
 
-    // 예측 결과 표시할 공간
     labelContainer = document.getElementById("label-container");
-    labelContainer.innerHTML = ""; // label-container 비우기
+    labelContainer.innerHTML = "";
 
     for (let i = 0; i < maxPredictions; i++) {
         labelContainer.appendChild(document.createElement("div"));
@@ -42,25 +40,23 @@ async function loop() {
 
 async function predict() {
     const prediction = await model.predict(webcam.canvas);
-    let currentLabel = ""; // 현재 상태
+    let currentLabel = "";
 
-    // 푸쉬업과 푸쉬다운 상태를 감지
     for (let i = 0; i < maxPredictions; i++) {
         const classPrediction = prediction[i].className + ": " + prediction[i].probability.toFixed(2);
         labelContainer.childNodes[i].innerHTML = classPrediction;
 
         if (prediction[i].probability.toFixed(2) > 0.7) {
-            currentLabel = prediction[i].className; // 확률이 70% 이상인 상태를 현재 상태로 설정
+            currentLabel = prediction[i].className;
         }
     }
 
-    // 상태 변화 감지 로직 (pushdown -> pushup)
     if (lastLabel === "pushdown" && currentLabel === "pushup") {
-        counter++; // 카운트 증가
-        document.getElementById("counter").innerText = counter; // 화면에 카운트 업데이트
+        counter++;
+        document.getElementById("counter").innerText = counter;
     }
 
-    lastLabel = currentLabel; // 마지막 상태 업데이트
+    lastLabel = currentLabel;
 }
 
 export { getCounter, init };

--- a/src/views/ChallengePlayView.vue
+++ b/src/views/ChallengePlayView.vue
@@ -1,0 +1,170 @@
+<template>
+    <div>
+        <div id="ui-container">
+            <transition name="fade" mode="out-in">
+                <template v-if="countdown > 0">
+                    <div :key="countdown" id="countdown-container">{{ countdown }}</div>
+                </template>
+                <template v-else>
+                    <div id="temp-container">
+                        <div id="label-container">Prediction Label</div>
+                        <div v-if="showCounter" :key="counter" id="counter-container" class="animate-counter">
+                            <span id="counter">{{ counter }}</span>
+                        </div>
+                    </div>
+                </template>
+            </transition>
+        </div>
+
+        <div id="webcam-container"></div>
+    </div>
+</template>
+
+<script setup>
+import { nextTick, ref, onMounted, onUnmounted } from 'vue';
+import { getCounter, init as tmInit } from '@/utils/teachableMachineForChallenge';
+
+const counter = ref(0);
+const showCounter = ref(false);
+const countdown = ref(3);
+let updateInterval = null;
+
+onUnmounted(() => {
+    if (updateInterval) {
+        clearInterval(updateInterval);
+    }
+});
+
+onMounted(() => {
+    startCountdown();
+});
+
+function startCountdown() {
+    function countdownStep() {
+        if (countdown.value > 0) {
+            countdown.value -= 1;
+
+            console.log(countdown.value)
+
+            nextTick(() => {
+                setTimeout(countdownStep, 1500);
+            });
+        } else {
+            countdown.value = 0;
+            startGame();
+        }
+    }
+
+    countdownStep();
+}
+
+function startGame() {
+    tmInit();
+
+    updateInterval = setInterval(async () => {
+        try {
+            const newCounterValue = await getCounter();
+            if (newCounterValue !== counter.value) {
+                counter.value = newCounterValue;
+                showCounter.value = true;
+                setTimeout(() => {
+                    showCounter.value = false;
+                }, 1500);
+            }
+        } catch (error) {
+            console.error("카운터 업데이트 중 오류 발생:", error);
+        }
+    }, 100);
+}
+</script>
+
+
+<style scoped>
+#temp-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    font-family: 'Comic Neue', 'Poppins', sans-serif;
+    position: relative;
+    height: 95vh;
+    gap: 10px;
+    z-index: 10;
+}
+
+#ui-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    font-family: 'Comic Neue', 'Poppins', sans-serif;
+    position: relative;
+    width: 100vw;
+    height: 100vh;
+    gap: 10px;
+    background: radial-gradient(circle, rgba(255, 255, 255, 0.1), rgba(0, 0, 0, 0.8));
+    animation: background-pulse 3s infinite alternate ease-in-out;
+    overflow: hidden;
+}
+
+#countdown-container {
+    font-size: 15rem;
+    font-weight: bold;
+    color: #ff3b3b;
+    text-shadow: 0px 0px 15px rgba(255, 0, 0, 0.8);
+    animation: countdown-zoom 1s ease-in-out, fadeIn 1s ease-in-out;
+}
+
+@keyframes countdown-zoom {
+    0% { transform: scale(0.8); opacity: 0; }
+    50% { transform: scale(1.2); opacity: 1; }
+    100% { transform: scale(1); opacity: 1; }
+}
+
+@keyframes background-pulse {
+    0% { background-color: rgba(0, 0, 0, 0.8); }
+    50% { background-color: rgba(50, 0, 0, 0.9); }
+    100% { background-color: rgba(0, 0, 0, 0.8); }
+}
+
+@keyframes fadeIn {
+    0% { opacity: 0; }
+    100% { opacity: 1; }
+}
+
+#label-container {
+    font-size: 1.5rem;
+    text-align: center;
+    font-weight: bold;
+    color: #4b5563;
+}
+
+#counter-container {
+    font-size: 10rem;
+    font-weight: bold;
+    color: #a9b6aa;
+    text-shadow: 0px 0px 15px rgba(62, 66, 61, 0.8);
+}
+
+.animate-counter {
+    animation: counter-zoom 1s ease-in-out;
+}
+
+@keyframes counter-zoom {
+    0% { transform: scale(1); opacity: 0; }
+    50% { transform: scale(1.5); opacity: 1; }
+    100% { transform: scale(1); opacity: 1; }
+}
+
+#webcam-container {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: none;
+    border-radius: 0;
+    overflow: hidden;
+    background-color: transparent;
+}
+</style>

--- a/src/views/GamePlayView.vue
+++ b/src/views/GamePlayView.vue
@@ -1,6 +1,5 @@
 <template>
     <div>
-        <!-- Pixi.js 전체 화면 -->
         <transition name="fade" mode="out-in">
             <template v-if="countdown > 0">
                 <div class="countdown-container">
@@ -11,16 +10,12 @@
                 <div>
                     <div id="pixi-container"></div>
 
-                    <!-- UI 컨테이너 -->
                     <div id="ui-container">
                         <div id="label-container">Prediction Label</div>
                         <div id="counter-container">Count: <span id="counter">{{ counter }}</span></div>
                     </div>
-
-                    <!-- 웹캠 컨테이너 -->
                     <div id="webcam-container"></div>
 
-                    <!-- 게임 상태 오버레이 -->
                     <div id="game-over-overlay" v-if="isGameOver">
                         <div id="game-over-text">GAME OVER</div>
                     </div>
@@ -37,7 +32,6 @@
 <script setup>
 import { ref, onMounted, nextTick, onUnmounted } from 'vue';
 import { Application, Sprite, Assets, Text } from 'pixi.js';
-// TM.js 기능 가져오기
 import { getCounter, init as tmInit } from '@/utils/teachableMachineForGame';
 
 const app = ref(null);
@@ -54,8 +48,6 @@ onUnmounted(() => {
     }
 });
 
-
-// Pixi.js 애플리케이션 및 게임 로직 초기화
 async function startPixiAndTM() {
     app.value = new Application();
     await app.value.init({
@@ -78,13 +70,11 @@ async function startPixiAndTM() {
         await Assets.load('/images/rabbit/rabbit9.png')
     ];
 
-    // 배경 이미지 추가
     const background = new Sprite(backgroundTexture);
     background.width = app.value.screen.width;
     background.height = app.value.screen.height;
     app.value.stage.addChild(background);
 
-    // 러너(캐릭터) 초기화
     const runner = new Sprite(runnerTextures[0]);
     runner.x = 200;
     const gameOverLimit = 40;
@@ -92,13 +82,11 @@ async function startPixiAndTM() {
     runner.scale.set(0.5);
     app.value.stage.addChild(runner);
 
-    // 애니메이션 제어 변수 초기화
     let frame = 0;
     let frameCounter = 0;
     const frameInterval = 10;
     let counterValue = 0;
     let isFalling = false;
-
 
     function updateRunnerAnimation() {
         frameCounter++;
@@ -109,7 +97,6 @@ async function startPixiAndTM() {
         }
     }
 
-    // TM.js 초기화
     await tmInit();
 
     async function updateCounter() {


### PR DESCRIPTION
## 연관된 이슈

> #8 #20 

## 작업 내용

> 챌린지 플레이 화면을 구현하였습니다.
>> 전체화면으로 구성됩니다.
>> 챌린지 시작 전에 카운트 다운을 구현하였습니다.
>> 챌린지 게임 도중, 운동 카운트의 효과를 추가하여 사용자에게 좋은 가독성을 제공합니다.
>> Teachable Machine의 웹캠의 크기가 달라짐에 따라 게임에 대한 코드와 챌린지에 대한 코드로 분리하였습니다.
>
> 게임 플레이 화면에서 스타트 버튼을 클릭하여 시작하는 방식에서 카운트 다운 후 시작하는 방식으로 변경하였습니다.

### 스크린샷 (선택)
### 게임과 챌린지 플레이 화면의 카운트 다운
![스크린샷 2024-11-12 115013](https://github.com/user-attachments/assets/a4870fbb-6809-43a6-9869-aa1ba5a671cc)

### 챌린지 플레이 화면의 운동 카운트 효과
![스크린샷 2024-11-12 115228](https://github.com/user-attachments/assets/9190493e-3635-43b1-abef-af5f3890b247)

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?