### PR TITLE
버튼 기능과 페이지 이동

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { RouterView, useRoute } from 'vue-router';
-import { computed, watch, ref } from 'vue';
+import { watch, ref } from 'vue';
 import Header from './components/HeaderNav.vue'
 
 const route = useRoute();
@@ -9,7 +9,7 @@ const showHeader = ref(false);
 watch(
   () => route.name,
   (newRouteName) => {
-    showHeader.value = ['ChallengeSelectView', 'GameSelectView'].includes(newRouteName);
+    showHeader.value = ['ChallengeSelectView', 'GameSelectView', 'FailScreen', 'SuccessScreen'].includes(newRouteName);
   },
   { immediate: true }
 );

--- a/src/components/FailScreen.vue
+++ b/src/components/FailScreen.vue
@@ -1,108 +1,181 @@
 <template>
-    <div>
-        <div id="game-over-overlay" v-if="isGameOver">
-            <div id="game-over-text">GAME OVER</div>
-            <div id="retry-message">다시 도전하려면 아래 버튼을 눌러주세요.</div>
-            <button class="retry-button" @click="retryGame">RETRY</button>
-        </div>
+  <div>
+    <div id="game-over-overlay" v-if="isGameOver">
+      <div id="game-over-text">GAME OVER</div>
+      <div id="retry-message">다시 도전하려면 아래 버튼을 눌러주세요.</div>
+      <button class="retry-button" @click="retryGame">다시하기</button>
+      <button class="new-challenge-button" @click="newGame">새로운 게임하기</button>
     </div>
+  </div>
 </template>
 
 <script setup>
 import { ref } from 'vue';
+import { useRouter, useRoute } from 'vue-router';
+
+const router = useRouter();
+const route = useRoute();
 
 const gameStarted = ref(false);
 const isGameOver = ref(true);
 
+const newGame = () => {
+  isGameOver.value = false;
+  router.push({ name: 'GameSelectView' });
+};
+
 const retryGame = () => {
-    isGameOver.value = false;
-    gameStarted.value = false;
-    console.log("Game restarted!");
+  isGameOver.value = false;
+  gameStarted.value = false;
+  router.push({
+        name: 'GamePlayView',
+        query: {
+            type: route.query.type,
+            level: route.query.level
+        }
+    });
 };
 </script>
 
 <style scoped>
 #game-over-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100vw;
-    height: 100vh;
-    background: rgba(0, 0, 0, 0.8);
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    flex-direction: column;
-    z-index: 100;
-    color: white;
-    text-align: center;
-    transition: all 0.3s ease-in-out;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  z-index: 100;
+  color: white;
+  text-align: center;
+  transition: all 0.3s ease-in-out;
 }
 
 #game-over-text {
-    font-size: 6rem;
-    font-weight: bold;
-    color: #ff3b3b;
-    text-shadow: 0px 0px 10px rgba(255, 0, 0, 0.8);
-    animation: shake 0.5s ease-in-out infinite alternate, fadeIn 1.5s ease-in-out;
+  font-size: 8rem;
+  font-weight: bold;
+  color: #ff3b3b;
+  text-shadow: 0px 0px 10px rgba(255, 0, 0, 0.8);
+  animation: shake 0.5s ease-in-out infinite alternate, fadeIn 1.5s ease-in-out;
 }
 
 #retry-message {
-    font-size: 1.5rem;
-    margin-top: 20px;
-    color: #ff8080;
-    animation: fadeIn 1.5s ease-in-out;
+  font-size: 1.5rem;
+  margin-top: 50px;
+  color: #ff8080;
+  animation: fadeIn 1.5s ease-in-out;
 }
 
 @keyframes shake {
-    0% {
-        transform: translate(0, 0);
-    }
+  0% {
+    transform: translate(0, 0);
+  }
 
-    25% {
-        transform: translate(-5px, 0);
-    }
+  25% {
+    transform: translate(-5px, 0);
+  }
 
-    50% {
-        transform: translate(5px, 0);
-    }
+  50% {
+    transform: translate(5px, 0);
+  }
 
-    75% {
-        transform: translate(-5px, 0);
-    }
+  75% {
+    transform: translate(-5px, 0);
+  }
 
-    100% {
-        transform: translate(0, 0);
-    }
+  100% {
+    transform: translate(0, 0);
+  }
 }
 
 @keyframes fadeIn {
-    0% {
-        opacity: 0;
-    }
+  0% {
+    opacity: 0;
+  }
 
-    100% {
-        opacity: 1;
-    }
+  100% {
+    opacity: 1;
+  }
 }
 
 .retry-button {
-    font-family: 'HakgyoansimDunggeunmisoTTF-B';
-    margin-top: 30px;
-    padding: 15px 30px;
-    background-color: #ff3b3b;
-    border: none;
-    color: white;
-    font-size: 1.5rem;
-    font-weight: bold;
-    border-radius: 12px;
-    cursor: pointer;
-    box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.3);
-    transition: background-color 0.3s ease;
+  font-family: 'HakgyoansimDunggeunmisoTTF-B';
+  margin-top: 40px;
+  padding: 20px 40px;
+  background-color: #ff3b3b;
+  border: none;
+  color: white;
+  font-size: 2rem;
+  font-weight: bold;
+  border-radius: 12px;
+  cursor: pointer;
+  box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.3);
+  transition: background-color 0.3s ease;
+  animation: jittery 4s infinite;
 }
 
 .retry-button:hover {
-    background-color: #ff7070;
-    box-shadow: 0px 6px 12px rgba(0, 0, 0, 0.3);
+  background-color: #ff7070;
+  box-shadow: 0px 6px 12px rgba(0, 0, 0, 0.3);
+}
+
+.new-challenge-button {
+  font-family: 'HakgyoansimDunggeunmisoTTF-B';
+  margin-top: 80px;
+  padding: 20px 40px;
+  background-color: #4CAF50;
+  border: none;
+  color: white;
+  font-size: 2rem;
+  font-weight: bold;
+  border-radius: 12px;
+  cursor: pointer;
+  box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.3);
+  transition: background-color 0.3s ease;
+}
+
+.new-challenge-button:hover {
+  background-color: #66bb6a;
+  box-shadow: 0px 6px 12px rgba(0, 0, 0, 0.3);
+}
+
+@keyframes jittery {
+
+  5%,
+  50% {
+    transform: scale(1);
+  }
+
+  10% {
+    transform: scale(0.9);
+  }
+
+  15% {
+    transform: scale(1.15);
+  }
+
+  20% {
+    transform: scale(1.15) rotate(-5deg);
+  }
+
+  25% {
+    transform: scale(1.15) rotate(5deg);
+  }
+
+  30% {
+    transform: scale(1.15) rotate(-3deg);
+  }
+
+  35% {
+    transform: scale(1.15) rotate(2deg);
+  }
+
+  40% {
+    transform: scale(1.15) rotate(0);
+  }
 }
 </style>

--- a/src/components/SuccessScreen.vue
+++ b/src/components/SuccessScreen.vue
@@ -14,7 +14,7 @@
 
             <div class="exp-value" :style="{ '--total-exp': `'${addedExpString}'` }">현재 경험치: {{ expValue }} EXP</div>
 
-            <button class="new-challenge-button" @click="restartGame">NEW GAME</button>
+            <button class="new-challenge-button" @click="newGame">새로운 챌린지하기</button>
 
             <div v-for="firework in fireworks" :key="firework.id" class="firework"
                 :style="{ left: firework.left + '%', top: firework.top + '%', backgroundColor: firework.color }">
@@ -25,23 +25,25 @@
 
 <script setup>
 import { ref, onMounted, watch, computed } from 'vue';
+import { useRouter } from 'vue-router';
 import curTierImage from '@/assets/images/tier/tier_IRON.png';
 import nextTierImage from '@/assets/images/tier/tier_BRONZE.png';
+
+const router = useRouter();
 
 const curTierIcon = ref(curTierImage)
 const nextTierIcon = ref(nextTierImage)
 
 const isGameSuccess = ref(true);
 const fireworks = ref([]);
-const currentExp = ref(400);
-const addedExp = ref(30);
+const currentExp = ref(300);
+const addedExp = ref(200);
 const targetExp = ref(1000);
 const expValue = ref(currentExp.value);
 const expFilledBarWidth = ref((expValue.value / targetExp.value) * 100);
 
 const totalExp = currentExp.value + addedExp.value;
 
-// 경험치 증가에 따라 경험치 바 반영
 const increaseExp = () => {
     let interval = setInterval(() => {
         if (expValue.value < totalExp) {
@@ -52,7 +54,6 @@ const increaseExp = () => {
     }, 30);
 };
 
-// 경험치 값 변경에 따라 바 너비 업데이트
 watch(expValue, (newVal) => {
     expFilledBarWidth.value = (newVal / targetExp.value) * 100;
 });
@@ -76,9 +77,9 @@ onMounted(() => {
     increaseExp();
 });
 
-const restartGame = () => {
+const newGame = () => {
     isGameSuccess.value = false;
-    console.log("New game started!");
+    router.push({ name: 'GameSelectView' });
 };
 
 const addedExpString = computed(() => `+${addedExp.value} EXP!`);
@@ -101,7 +102,6 @@ const addedExpString = computed(() => `+${addedExp.value} EXP!`);
     text-align: center;
     overflow: hidden;
     transition: all 0.3s ease-in-out;
-
 }
 
 #success-text {
@@ -271,22 +271,58 @@ const addedExpString = computed(() => `+${addedExp.value} EXP!`);
 
 .new-challenge-button {
     font-family: 'HakgyoansimDunggeunmisoTTF-B';
-    margin-top: 30px;
-    padding: 15px 30px;
+    margin-top: 80px;
+    padding: 20px 40px;
     background-color: #4CAF50;
     border: none;
     color: white;
-    font-size: 1.5rem;
+    font-size: 2rem;
     font-weight: bold;
     border-radius: 12px;
     cursor: pointer;
     box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.3);
     transition: background-color 0.3s ease;
+    animation: jittery 4s infinite;
 }
 
 .new-challenge-button:hover {
     background-color: #66bb6a;
     box-shadow: 0px 6px 12px rgba(0, 0, 0, 0.3);
+}
+
+@keyframes jittery {
+  5%,
+  50% {
+    transform: scale(1);
+  }
+
+  10% {
+    transform: scale(0.9);
+  }
+
+  15% {
+    transform: scale(1.15);
+  }
+
+  20% {
+    transform: scale(1.15) rotate(-5deg);
+  }
+
+  25% {
+    transform: scale(1.15) rotate(5deg);
+  }
+
+  30% {
+    transform: scale(1.15) rotate(-3deg);
+  }
+
+  35% {
+    transform: scale(1.15) rotate(2deg);
+  }
+
+  40% {
+    transform: scale(1.15) rotate(0);
+  }
 }
 
 .exp-value {

--- a/src/views/ChallengeSelectView.vue
+++ b/src/views/ChallengeSelectView.vue
@@ -2,15 +2,30 @@
     <div>
         <div class="main-container">
             <div class="header-container">
-                <span class="header">챌린지 선택하기</span>
+                <span class="header">챌린지를 선택해주세요!</span>
+                <div class="subtitle">또는 챌린지를 수정, 삭제 및 추가할 수 있습니다.</div>
             </div>
+
+            <div v-if="isDeleteModalOpen" class="modal-overlay">
+                <div class="modal">
+                    <p>정말 삭제하시겠습니까?</p>
+                    <div class="modal-buttons">
+                        <button @click="confirmDelete" class="confirm-button">네</button>
+                        <button @click="closeDeleteModal" class="cancel-button">아니요</button>
+                    </div>
+                </div>
+            </div>
+
             <div class="challenge-container">
                 <div v-for="(challenge, index) in challenges" :key="index"
-                    :class="['challenge-box', isEditing && editIndex === index ? 'edit-box' : '']">
+                    :class="['challenge-box', isEditing && editIndex === index ? 'edit-box' : '', selectedChallenge === challenge ? 'selected' : '']"
+                    @click="selectChallenge(index)">
+
                     <div v-if="!(isEditing && editIndex === index)" class="icon-container">
                         <span @click="toggleEdit(index)" class="icon-button">✏️</span>
                         <span @click="deleteChallenge(index)" class="icon-button delete-icon">🗑️</span>
                     </div>
+
                     <div v-if="isEditing && editIndex === index" class="edit-form open">
                         <span @click="isEditing = false" class="icon-button close-button">❌</span>
                         <form @submit.prevent="saveChallenge">
@@ -46,6 +61,7 @@
                             </div>
                         </form>
                     </div>
+
                     <div v-else>
                         <div class="challenge-info-container">
                             <div class="banner">{{ challenge.name }}</div>
@@ -55,22 +71,25 @@
                             <div class="progress-bar">
                                 <div class="progress-fill" :style="{ width: challenge.progress + '%' }"></div>
                             </div>
-                            <button class="start-button" @click="startChallenge(challenge.id)">챌린지 시작</button>
                         </div>
                     </div>
                 </div>
+
                 <div v-if="!isCreating" @click="toggleForm" class="challenge-box new-challenge-box">
                     <div>+</div>
                     <div></div>
                 </div>
+
                 <div v-if="isCreating" class="challenge-box new-challenge-form open">
                     <form @submit.prevent="saveChallenge">
                         <span @click="isCreating = false" class="icon-button close-button2">❌</span>
+
                         <div class="challenge-info">
                             <label style="font-size: 1.2rem;">🏆 챌린지 이름</label>
                             <input type="text" v-model="newChallenge.name" class="input-field"
                                 placeholder="예: '30일 푸쉬업 챌린지'">
                         </div>
+
                         <div class="challenge-info">
                             <label style="text-align: center; font-size: 1.2rem;">🔥 운동 타입</label>
                             <div style="display: flex; justify-content: space-around; align-items: center;">
@@ -84,21 +103,34 @@
                                 </label>
                             </div>
                         </div>
+
                         <div class="challenge-info">
                             <label style="font-size: 1.2rem;">⏰ 종료 날짜</label>
                             <input type="date" v-model="newChallenge.date" class="input-field">
                         </div>
+
                         <div class="challenge-info">
                             <label style="font-size: 1.2rem;">🎯 하루 목표 갯수</label>
                             <input type="number" v-model="newChallenge.goal" class="input-field" placeholder="예: 30">
                         </div>
+
                         <div class="button-container">
                             <button type="submit" class="action-button">저장</button>
                         </div>
                     </form>
                 </div>
             </div>
+
+            <button @click="startChallenge(selectedChallenge.id)" class="custom-button" :disabled="!selectedChallenge"
+                :style="{ animation: selectedChallenge ? '' : 'jittery 4s infinite' }">
+                <span>시작하기</span>
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="4" width="130"
+                    height="130" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" width="80" height="80" d="M9 5l7 7-7 7" />
+                </svg>
+            </button>
         </div>
+        
         <div v-for="(icon, index) in floatingIcons" :key="index" class="floating-icon"
             :style="{ top: icon.top, left: icon.left, animationDuration: icon.speed }">
             {{ icon.icon }}
@@ -123,16 +155,40 @@ const newChallenge = reactive({ name: "", type: "Push Up", date: "", goal: null 
 const icons = ["💪", "❤️", "🏋️‍♂️", "🔥", "💚", "⏱️", "👟", "🏆", "💦", "🤸‍♀️", "🚴", "🏃", "🥇", "🏅", "🧘", "🩺", "🥗", "🍎", "🥤", "🚶"];
 const floatingIcons = ref([]);
 const editChallenge = reactive({ name: "", type: "", date: "", goal: null });
+const selectedChallenge = ref(null);
+const isDeleteModalOpen = ref(false);
+const deleteIndex = ref(null);
 
-const deleteChallenge = (index) => {
-    challenges.value.splice(index, 1);
+const selectChallenge = (index) => {
+    selectedChallenge.value = challenges.value[index];
 };
 
+const deleteChallenge = (index) => {
+    deleteIndex.value = index;
+    isDeleteModalOpen.value = true;
+};
+
+function confirmDelete() {
+    if (deleteIndex.value !== null) {
+        challenges.value.splice(deleteIndex.value, 1);
+        deleteIndex.value = null;
+    }
+    isDeleteModalOpen.value = false;
+}
+
+function closeDeleteModal() {
+    isDeleteModalOpen.value = false;
+}
+
 const startChallenge = (id) => {
-    router.push({ 
-        name: 'ChallengePlayView', 
-        params: { id: id } 
-    });
+    if (selectedChallenge.value) {
+        router.push({
+            name: 'ChallengePlayView',
+            params: { id: selectedChallenge.value.id }
+        });
+    } else {
+        alert("챌린지를 선택해주세요.");
+    }
 };
 
 const toggleEdit = (index) => {
@@ -203,10 +259,12 @@ onMounted(addFloatingIcons);
 
 <style scoped>
 .main-container {
+    position: relative;
+    top: 40px;
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 10px;
+    gap: 5px;
     transition: all 0.3s ease-in-out;
 }
 
@@ -247,8 +305,11 @@ onMounted(addFloatingIcons);
     box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
     text-align: center;
     position: relative;
-    transition: transform 0.3s, box-shadow 0.3s;
+    transition: transform 0.3s, box-shadow 0.3s, border-color 0.3s;
+    ;
     z-index: -1;
+    cursor: pointer;
+    border: 2px solid transparent;
 }
 
 .challenge-info-container {
@@ -267,6 +328,24 @@ onMounted(addFloatingIcons);
     margin: 8px 0;
 }
 
+.challenge-box.selected {
+    border-width: 5px;
+    border-color: #ff7043;
+    animation: highlight2 0.3s forwards;
+}
+
+@keyframes highlight2 {
+    0% {
+        transform: scale(1);
+        box-shadow: 0 0 0 rgba(255, 112, 67, 0);
+    }
+
+    100% {
+        transform: scale(1.05);
+        box-shadow: 0 0 15px rgba(255, 112, 67, 0.5);
+    }
+}
+
 .progress-bar {
     height: 12px;
     width: 100%;
@@ -283,23 +362,27 @@ onMounted(addFloatingIcons);
 
 .header-container {
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
-    margin-bottom: 20px;
     z-index: 10;
+    color: #ff7043;
+    background: #fff7e0;
+    border-radius: 25px;
+    box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.2);
+    padding: 20px 40px;
+    gap: 10px
 }
 
 .header {
-    font-size: 3rem;
+    font-size: 2.5rem;
     font-weight: bold;
-    color: #ff7043;
-    padding: 8px 20px;
-    background: rgba(255, 230, 204, 0.9);
-    border-radius: 25px;
-    box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.2);
-    text-align: center;
-    position: relative;
-    z-index: 10;
+}
+
+.subtitle {
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: #718096;
 }
 
 .banner {
@@ -310,7 +393,7 @@ onMounted(addFloatingIcons);
     max-width: 300px;
     height: 50px;
     border: 1px solid #8a1;
-    
+
     font: bold 25px/50px 'HakgyoansimDunggeunmisoTTF-B';
     text-align: center;
     color: #ffffff;
@@ -361,34 +444,6 @@ onMounted(addFloatingIcons);
     width: 60%;
     background-color: #ff7043;
     animation: fillProgress 1s forwards;
-}
-
-.start-button {
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    padding: 8px 12px; /* 패딩 줄임 */
-    background-color: #ff7043;
-    border: 3px solid #d95c37; /* 테두리 두께 줄임 */
-    border-radius: 9999px;
-    color: white;
-    font-size: 1rem; /* 폰트 크기 줄임 */
-    font-weight: bold;
-    cursor: pointer;
-}
-
-.start-button svg {
-    width: 20%; /* 너비 줄임 */
-    height: 40%; /* 높이 줄임 */
-}
-
-.start-button span {
-    margin-right: 6px; /* 오른쪽 여백 줄임 */
-}
-
-.start-button:hover {
-    background: #f06292;
-    transform: scale(1.05);
 }
 
 
@@ -552,6 +607,56 @@ onMounted(addFloatingIcons);
     color: #f44336;
 }
 
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.modal {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    background: white;
+    border-radius: 10px;
+    text-align: center;
+    font-size: 2rem;
+    width: 500px;
+    height: 300px;
+    line-height: 0;
+}
+
+.modal-buttons {
+    display: flex;
+    justify-content: space-around;
+    margin-top: 20px;
+}
+
+.confirm-button, .cancel-button {
+    padding: 10px 30px;
+    font-size: 2rem;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-family: 'HakgyoansimDunggeunmisoTTF-B';
+}
+
+.confirm-button {
+    background-color: #ff4d4d;
+    color: white;
+}
+
+.cancel-button {
+    background-color: #cccccc;
+}
+
 .close-button {
     position: absolute;
     top: -1%;
@@ -568,6 +673,81 @@ onMounted(addFloatingIcons);
     font-size: 18px;
     cursor: pointer;
     transition: color 0.3s;
+}
+
+.custom-button {
+    font-family: 'HakgyoansimDunggeunmisoTTF-B';
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    padding: 12px 15px;
+    background-color: #ff7043;
+    border: 4px solid #d95c37;
+    border-radius: 9999px;
+    color: white;
+    font-size: 2rem;
+    font-weight: bold;
+    cursor: pointer;
+    box-sizing: border-box;
+    animation: jittery 4s infinite;
+    z-index: 10;
+}
+
+.custom-button svg {
+    width: 30%;
+    height: 20%;
+}
+
+.custom-button span {
+    margin-right: 8px;
+}
+
+.custom-button:hover {
+    background: #f06292;
+    transform: scale(1.05);
+}
+
+.custom-button:disabled {
+    background-color: #cccccc;
+    border: #cccccc;
+    cursor: not-allowed;
+    box-shadow: none;
+}
+
+@keyframes jittery {
+
+    5%,
+    50% {
+        transform: scale(1);
+    }
+
+    10% {
+        transform: scale(0.9);
+    }
+
+    15% {
+        transform: scale(1.15);
+    }
+
+    20% {
+        transform: scale(1.15) rotate(-5deg);
+    }
+
+    25% {
+        transform: scale(1.15) rotate(5deg);
+    }
+
+    30% {
+        transform: scale(1.15) rotate(-3deg);
+    }
+
+    35% {
+        transform: scale(1.15) rotate(2deg);
+    }
+
+    40% {
+        transform: scale(1.15) rotate(0);
+    }
 }
 
 @keyframes float {


### PR DESCRIPTION
## 연관된 이슈

> #28 #35 #36 

## 작업 내용

- 기존의 챌린지 중 하나를 선택하여 챌린지를 시작할 수 있는 버튼을 만들었습니다.
- 기존의 챌린지 삭제 시, 삭제에 대한 추가 질문을 통해 사용자가 인지할 수 있도록 구현하였습니다.

- 게임 또는 챌린지 성공 시, 새로운 게임 또는 챌린지를 할 수 있는 버튼을 만들었습니다.
- 게임 실패 시, 다시하기 버튼과 새로운 게임하기 버튼을 만들었습니다.

- 각 버튼들을 클릭했을 때, 필요한 페이지 이동을 구현하였습니다.

### 스크린샷 (선택)
### 챌린지 선택
![스크린샷 2024-11-15 095500](https://github.com/user-attachments/assets/cb71722f-a1b8-4660-a3fd-172783adfb55)

### 성공 화면
![스크린샷 2024-11-15 102139](https://github.com/user-attachments/assets/4ee0b3ea-a21d-4214-8e06-1c88f4df9da0)

### 실패 화면
![스크린샷 2024-11-15 102156](https://github.com/user-attachments/assets/79c61684-9a90-4a10-a9ea-3d588867e482)