### PR TITLE
플레이 화면 구성

### DIFF
--- a/src/utils/teachableMachineForChallenge.js
+++ b/src/utils/teachableMachineForChallenge.js
@@ -1,5 +1,6 @@
 const URL = '/model/';
 let model, webcam, labelContainer, maxPredictions, counter = 0, lastLabel = "";
+let animationFrameId = null;
 
 async function getCounter() {
     return counter;
@@ -24,7 +25,7 @@ async function init() {
         console.error("웹캠 설정 실패: ", error);
     }
 
-    window.requestAnimationFrame(loop);
+    animationFrameId = window.requestAnimationFrame(loop);
 
     labelContainer = document.getElementById("label-container");
     if (labelContainer) {
@@ -39,7 +40,7 @@ async function loop() {
     if (webcam) {
         webcam.update();
         await predict();
-        window.requestAnimationFrame(loop);
+        animationFrameId = window.requestAnimationFrame(loop);
     }
 }
 
@@ -70,4 +71,35 @@ async function predict() {
     lastLabel = currentLabel;
 }
 
-export { getCounter, init };
+function stop() {
+    if (webcam && webcam.stream && webcam.stream.getTracks) {
+        webcam.stream.getTracks().forEach(track => track.stop());
+        console.log("웹캠 스트림 중지");
+    } else {
+        console.warn("웹캠이 초기화되지 않았거나 이미 중지되었습니다.");
+    }
+
+    if (animationFrameId) {
+        window.cancelAnimationFrame(animationFrameId);
+        animationFrameId = null;
+        console.log("애니메이션 루프 중지");
+    }
+
+    if (model) {
+        model = null;
+        console.log("모델 해제 완료");
+    }
+
+    if (labelContainer) {
+        labelContainer.innerHTML = "";
+        console.log("라벨 컨테이너 초기화");
+    }
+
+    counter = 0;
+    lastLabel = "";
+    console.log("카운터 초기화 완료");
+
+    console.log("Teachable Machine 세션이 종료되었습니다.");
+}
+
+export { getCounter, init, stop };

--- a/src/utils/teachableMachineForGame.js
+++ b/src/utils/teachableMachineForGame.js
@@ -1,5 +1,6 @@
 const URL = '/model/';
 let model, webcam, labelContainer, maxPredictions, counter = 0, lastLabel = "";
+let animationFrameId;
 
 async function getCounter() {
     return counter;
@@ -53,10 +54,46 @@ async function predict() {
 
     if (lastLabel === "pushdown" && currentLabel === "pushup") {
         counter++;
-        document.getElementById("counter").innerText = counter;
+        
+        const counterElement = document.getElementById("counter");
+        if (counterElement) {
+            counterElement.innerText = counter;
+        } else {
+            console.warn("'#counter' 요소가 DOM에 존재하지 않습니다.");
+        }
     }
 
     lastLabel = currentLabel;
 }
 
-export { getCounter, init };
+function stop() {
+    if (webcam && webcam.stream && webcam.stream.getTracks) {
+        webcam.stream.getTracks().forEach(track => track.stop());
+        console.log("웹캠 스트림 중지");
+    } else {
+        console.warn("웹캠이 초기화되지 않았거나 이미 중지되었습니다.");
+    }
+
+    if (animationFrameId) {
+        window.cancelAnimationFrame(animationFrameId);
+        animationFrameId = null;
+        console.log("애니메이션 루프 중지");
+    }
+
+    if (model) {
+        model = null;
+        console.log("모델 해제 완료");
+    }
+
+    if (labelContainer) {
+        labelContainer.innerHTML = "";
+        console.log("라벨 컨테이너 초기화");
+    }
+
+    counter = 0;
+    lastLabel = "";
+    console.log("Teachable Machine 세션이 종료되었습니다.");
+}
+
+
+export { getCounter, init, stop };

--- a/src/views/ChallengePlayView.vue
+++ b/src/views/ChallengePlayView.vue
@@ -17,17 +17,37 @@
         </div>
 
         <div id="webcam-container"></div>
+
+        <button v-if="countdown === 0" @click="openSaveModal" class="save-button">저장하기</button>
+
+        <div v-if="isModalOpen" class="modal-overlay">
+            <div class="modal">
+                <p>현재까지의 운동 횟수: {{ counter }}</p>
+                <p>저장하시겠습니까?</p>
+                <div class="modal-buttons">
+                    <button @click="saveAndNavigate" class="confirm-button">저장</button>
+                    <button @click="closeModal" class="cancel-button">취소</button>
+                </div>
+            </div>
+        </div>
     </div>
 </template>
 
 <script setup>
+import { useRouter } from 'vue-router';
 import { nextTick, ref, onMounted, onUnmounted } from 'vue';
 import { getCounter, init as tmInit } from '@/utils/teachableMachineForChallenge';
 
 const counter = ref(0);
 const showCounter = ref(false);
 const countdown = ref(3);
+const isModalOpen = ref(false);
+const router = useRouter();
 let updateInterval = null;
+
+onMounted(() => {
+    startCountdown();
+});
 
 onUnmounted(() => {
     if (updateInterval) {
@@ -35,9 +55,19 @@ onUnmounted(() => {
     }
 });
 
-onMounted(() => {
-    startCountdown();
-});
+function openSaveModal() {
+    isModalOpen.value = true;
+}
+
+function closeModal() {
+    isModalOpen.value = false;
+}
+
+function saveAndNavigate() {
+    console.log(`저장된 운동 횟수: ${counter.value}`);
+    isModalOpen.value = false;
+    router.push({ name: 'ChallengeSelectView' });
+}
 
 function startCountdown() {
     function countdownStep() {
@@ -167,5 +197,75 @@ function startGame() {
     border-radius: 0;
     overflow: hidden;
     background-color: transparent;
+}
+
+.save-button {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    padding: 20px 40px;
+    background-color: #4CAF50;
+    color: white;
+    border: none;
+    border-radius: 10px;
+    cursor: pointer;
+    font-size: 1.5rem;
+    transition: background-color 0.3s;
+    font-family: 'HakgyoansimDunggeunmisoTTF-B';
+}
+
+.save-button:hover {
+    background-color: #45a049;
+}
+
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.modal {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    background: white;
+    border-radius: 10px;
+    text-align: center;
+    font-size: 2rem;
+    width: 500px;
+    height: 300px;
+    line-height: 0;
+}
+
+.modal-buttons {
+    display: flex;
+    justify-content: space-around;
+    margin-top: 20px;
+}
+
+.confirm-button, .cancel-button {
+    padding: 10px 40px;
+    font-size: 2rem;
+    cursor: pointer;
+    border: none;
+    border-radius: 5px;
+    font-family: 'HakgyoansimDunggeunmisoTTF-B';
+}
+
+.confirm-button {
+    background-color: #4CAF50;
+    color: white;
+}
+
+.cancel-button {
+    background-color: #f44336;
+    color: white;
 }
 </style>

--- a/src/views/GamePlayView.vue
+++ b/src/views/GamePlayView.vue
@@ -16,27 +16,32 @@
                     </div>
                     <div id="webcam-container"></div>
 
-                    <div id="game-over-overlay" v-if="isGameOver">
-                        <div id="game-over-text">GAME OVER</div>
-                    </div>
-                    <div id="success-overlay" v-if="isSuccess">
-                        <div id="success-text">SUCCESS</div>
-                    </div>
+                    <button v-if="countdown === 0" @click="openEndModal" class="end-button">끝내기</button>
                 </div>
 
             </template>
         </transition>
+
+        <div v-if="isEndModalOpen" class="modal-overlay">
+            <div class="modal">
+                <p>정말 끝내시겠습니까?</p>
+                <div class="modal-buttons">
+                    <button @click="navigateToGameSelect" class="confirm-button">네</button>
+                    <button @click="closeEndModal" class="cancel-button">아니요</button>
+                </div>
+            </div>
+        </div>
     </div>
 </template>
 
 <script setup>
-import { useRouter, useRoute } from 'vue-router';
+import { useRouter } from 'vue-router';
 import { ref, onMounted, nextTick, onUnmounted } from 'vue';
 import { Application, Sprite, Assets, Text } from 'pixi.js';
-import { getCounter, init as tmInit } from '@/utils/teachableMachineForGame';
+import { getCounter, init as tmInit, stop as tmStop } from '@/utils/teachableMachineForGame';
 
 const router = useRouter();
-const route = useRoute();
+const isEndModalOpen = ref(false);
 
 const app = ref(null);
 const counter = ref(0);
@@ -46,14 +51,30 @@ const isSuccess = ref(false);
 const countdown = ref(4);
 let updateInterval = null;
 
+function openEndModal() {
+    isEndModalOpen.value = true;
+}
+
+function closeEndModal() {
+    isEndModalOpen.value = false;
+}
+
+function navigateToGameSelect() {
+    isGameOver.value = true;
+    if (app.value) {
+        app.value.ticker.stop();
+    }
+    tmStop();
+    router.push({ name: 'GameSelectView' });
+}
+
 onUnmounted(() => {
     if (updateInterval) {
         clearInterval(updateInterval);
     }
-});
 
-const selectedType = route.query.type;
-const selectedLevel = route.query.level;
+    tmStop();
+});
 
 async function startPixiAndTM() {
     app.value = new Application();
@@ -163,8 +184,8 @@ async function startPixiAndTM() {
     }
 
     app.value.ticker.add(() => {
-        updateCounter();
         if (!isGameOver.value && !isSuccess.value) {
+            updateCounter();
             updateRunnerAnimation();
             moveRunnerLeft();
         }
@@ -240,35 +261,6 @@ onMounted(() => {
     transition: all 0.3s ease-in-out;
 }
 
-#game-over-overlay,
-#success-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100vw;
-    height: 100vh;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    z-index: 3;
-    pointer-events: none;
-}
-
-#game-over-text,
-#success-text {
-    font-size: 10rem;
-    font-weight: bold;
-    text-align: center;
-}
-
-#game-over-text {
-    color: red;
-}
-
-#success-text {
-    color: green;
-}
-
 #countdown-container {
     font-size: 15rem;
     font-weight: bold;
@@ -325,6 +317,77 @@ onMounted(() => {
     color: #ffffff;
     text-shadow: 0px 0px 15px rgba(0, 0, 0, 0.8);
 }
+
+.end-button {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    padding: 15px 40px;
+    background-color: #ff7043;
+    color: white;
+    border: none;
+    border-radius: 10px;
+    cursor: pointer;
+    font-size: 1.5rem;
+    transition: background-color 0.3s;
+    font-family: 'HakgyoansimDunggeunmisoTTF-B';
+}
+
+.end-button:hover {
+    background-color: #f06292;
+}
+
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.modal {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    background: white;
+    border-radius: 10px;
+    text-align: center;
+    font-size: 2rem;
+    width: 500px;
+    height: 300px;
+    line-height: 0;
+}
+
+.modal-buttons {
+    display: flex;
+    justify-content: space-around;
+    margin-top: 20px;
+}
+
+.confirm-button,
+.cancel-button {
+    padding: 10px 30px;
+    font-size: 2rem;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-family: 'HakgyoansimDunggeunmisoTTF-B';
+}
+
+.confirm-button {
+    background-color: #ff7043;
+    color: white;
+}
+
+.cancel-button {
+    background-color: #cccccc;
+}
+
 
 @keyframes background-pulse {
     0% {

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1,7 +1,6 @@
 <template>
     <div class="mypage-container">
 
-        <!-- 유저 정보 -->
         <div class="box user-info">
             <div class="user-details">
                 <h2 class="nickname">{{ user.nickname }}</h2>
@@ -63,23 +62,20 @@
                     <h5 class="info-section">
                         보너스 경험치
                     </h5>
-                    <div class="highlight time-remaining">10 exp (Day-4)</div>
-                    <div class="highlight time-remaining">100 exp (Day-26)</div>
+                    <div class="highlight time-remaining">10 exp (D-day 4)</div>
+                    <div class="highlight time-remaining">100 exp (D-day 26)</div>
                 </div>
             </div>
         </div>
 
-
-
         <div class="right-section">
             <div class="top-section">
-                <!-- 티어 정보 -->
                 <div class="box tier-container">
                     <div class="tier">
                         <div class="tier-pic-wrapper">
                             <img class="tier-pic" :src="user.curTierIcon" alt="현재 티어 사진" />
                             <button @click="toggleRankings" class="info-button" aria-label="티어 설명">
-                                <img src="@/assets/images/icon/info-icon.png" alt="티어 설명 아이콘" class="info-icon" />
+                                <img src="@/assets/images/icon/heart-icon.png" alt="티어 설명 아이콘" class="heart-icon" />
                             </button>
                         </div>
                         <span>{{ user.tier }}</span>
@@ -88,17 +84,15 @@
                     <div class="exp-tier-container">
                         <img class="exp-tier-pic" :src="user.curTierIcon" alt="현재 티어 사진" />
                         <div class="exp-bar-container">
-                            <div class="exp-bar-fill" :style="{ width: expPercent + '%' }"></div>
-                            <div class="exp-text">{{ user.exp }} / {{ user.maxExp }}</div>
+                            <div class="exp-bar-fill" :style="{ width: expFilledBarWidth + '%' }"></div>
+                            <div class="exp-text">{{ user.exp }} / {{ user.maxExp }} exp</div>
                         </div>
                         <img class="exp-tier-pic" :src="user.nextTierIcon" alt="다음 티어 사진" />
                     </div>
                 </div>
 
-                <!-- 오버레이 -->
                 <div :class="['overlay', { show: showRankings }]" @click="toggleRankings"></div>
 
-                <!-- 티어 정보 -->
                 <div v-if="showRankings" :class="['rankings-container', { show: showRankings }]">
                     <table class="tier-table">
                         <tbody>
@@ -127,21 +121,19 @@
                     </table>
                 </div>
 
-
                 <div class="box3-and-buttons">
                     <div class="box box3">박스3</div>
 
-                    <!-- 버튼 -->
                     <div class="button-container">
                         <button @click="startChallenge" class="custom-button">
-                            <span>🏆 챌린지 시작</span>
+                            <span>🏆 챌린지 하기</span>
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="5"
                                 stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
                             </svg>
                         </button>
                         <button @click="startGame" class="custom-button">
-                            <span>🎮 게임 시작</span>
+                            <span>🎮 게임 하기</span>
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="5"
                                 stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
@@ -151,7 +143,6 @@
                 </div>
             </div>
 
-            <!-- 캘린더 -->
             <div class="box calendar">
                 <div class="calendar-header">
                     <button class="month-btn" @click="prevMonth">〈</button>
@@ -175,7 +166,6 @@
             </div>
         </div>
 
-        <!-- 배경 아이콘 -->
         <div v-for="(icon, index) in floatingIcons" :key="index" class="floating-icon"
             :style="{ top: icon.top, left: icon.left, animationDuration: icon.speed }">
             {{ icon.icon }}
@@ -184,7 +174,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue';
+import { ref, computed, onMounted, watch } from 'vue';
 import { useRouter } from 'vue-router';
 
 import exampleImage from '@/assets/images/character/example.jpg';
@@ -245,14 +235,29 @@ const user = ref({
     maxExp: 3000,
 });
 
-const startChallenge = () => {
-  router.push({ name: 'ChallengePlayView' });
-};
-const startGame = () => {
-  router.push({ name : 'GamePlayView' })  
+const expValue = ref(0)
+const expFilledBarWidth = ref(0);
+
+const increaseExp = () => {
+    let interval = setInterval(() => {
+        if (expValue.value < user.value.exp) {
+            expValue.value += 10;
+        } else {
+            clearInterval(interval);
+        }
+    }, 10);
 };
 
-const expPercent = computed(() => (user.value.exp / user.value.maxExp) * 100);
+watch(expValue, (newVal) => {
+    expFilledBarWidth.value = (newVal / user.value.maxExp) * 100;
+});
+
+const startChallenge = () => {
+  router.push({ name: 'ChallengeSelectView' });
+};
+const startGame = () => {
+  router.push({ name : 'GameSelectView' })  
+};
 
 const currentMonth = ref(new Date().getMonth() + 1);
 const currentYear = ref(new Date().getFullYear());
@@ -311,10 +316,10 @@ const addFloatingIcons = () => {
     }
 };
 
-onMounted(addFloatingIcons);
-
 onMounted(() => {
+    addFloatingIcons()
     generateCalendar();
+    increaseExp();
 });
 </script>
 
@@ -683,6 +688,8 @@ onMounted(() => {
     font-weight: bold;
     color: #660000;
     font-size: 1.3vw;
+    width: 100%;
+    text-align: center;
 }
 
 /* 티어 정보 섹션 */

--- a/src/views/StartView.vue
+++ b/src/views/StartView.vue
@@ -14,7 +14,7 @@
             </div>
 
             <div class="button-container">
-                <button class="custom-button">
+                <button class="custom-button" @click="navigateToLogin">
                     <span>시작하기</span>
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="6"
                         stroke="black">
@@ -36,11 +36,16 @@
 
 <script setup>
 import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router';
 
-
+const router = useRouter();
 const floatingIcons = ref([]);
 const icons = ["💪", "❤️", "🏋️‍♂️", "🔥", "💚", "⏱️", "👟", "🏆", "💦", "🤸‍♀️",
     "🚴", "🏃", "🥇", "🏅", "🧘", "🩺", "🥗", "🍎", "🥤", "🚶"];
+
+function navigateToLogin() {
+    router.push({ name: 'LoginView' });
+}
 
 const createFloatingIcons = () => {
     for (let i = 0; i < 60; i++) {
@@ -127,14 +132,14 @@ onMounted(() => {
     font-size: 4rem;
     font-weight: bold;
     cursor: pointer;
-    animation: pulse 1.5s infinite;
+    animation: jittery 4s infinite;
     position: relative;
     z-index: 10;
 }
 
 .custom-button svg {
     width: 30%;
-    height: 50%;
+    height: 40%;
 }
 
 .custom-button span {
@@ -146,16 +151,39 @@ onMounted(() => {
     transform: scale(1.05);
 }
 
-@keyframes pulse {
+@keyframes jittery {
+  5%,
+  50% {
+    transform: scale(1);
+  }
 
-    0%,
-    100% {
-        transform: scale(1);
-    }
+  10% {
+    transform: scale(0.9);
+  }
 
-    50% {
-        transform: scale(1.05);
-    }
+  15% {
+    transform: scale(1.15);
+  }
+
+  20% {
+    transform: scale(1.15) rotate(-5deg);
+  }
+
+  25% {
+    transform: scale(1.15) rotate(5deg);
+  }
+
+  30% {
+    transform: scale(1.15) rotate(-3deg);
+  }
+
+  35% {
+    transform: scale(1.15) rotate(2deg);
+  }
+
+  40% {
+    transform: scale(1.15) rotate(0);
+  }
 }
 
 .floating-icon {


### PR DESCRIPTION
## 연관된 이슈

> #23 

## 작업 내용

- 챌린지 플레이 시, 저장하기 버튼을 만들었습니다.
- 저장하기 버튼을 클릭했을 때, 운동 갯수를 보여주고, 저장 버튼과 취소 버튼을 만들었습니다.
- 저장 버튼을 누르면 해당 운동 갯수가 저장되고, 챌린지 선택 화면으로 이동합니다.
- 저장 버튼을 누른 후에 티쳐블 머신의 모델과 웹캠 설정들이 초기화 되어야하기 때문에 티쳐블 머신의 설정들을 초기화해주는 stop() 메서드를 티쳐블머신 코드에 추가하였습니다.

- 게임 플레이 시, 끝내기 버튼을 만들었습니다.
- 끝내기 버튼은 따로 운동 갯수를 보여주지 않고, 게임을 끝낼지에 대한 네 버튼과 아니오 버튼을 만들었습니다.
- 네 버튼을 누르면 게임 선택 화면으로 이동하고, 챌린지 플레이와 마찬가지로 티쳐블 머신의 설정들을 초기화해야하기 때문에 게임을 위한 티쳐블머신 코드에 stop() 메서드를 추가하였습니다.

### 스크린샷 (선택)
### 챌린지 저장하기 버튼
![스크린샷 2024-11-15 114035](https://github.com/user-attachments/assets/36c58d91-aacb-46a5-bad1-d9a9c5a47594)

### 챌린지 저장 질문 버튼
![스크린샷 2024-11-15 114046](https://github.com/user-attachments/assets/a5e2185c-09d7-421a-8600-03b6f1818051)

### 게임 끝내기 버튼
![스크린샷 2024-11-15 114004](https://github.com/user-attachments/assets/d2bbfd43-8f26-4ee0-b898-860f94c55b8b)

### 게임 끝내기 질문 버튼
![스크린샷 2024-11-15 114013](https://github.com/user-attachments/assets/e54bab95-b082-49fd-a465-29c6459a63fb)

## 리뷰 참고사항 (선택)

- 애니메이션 추가의 경우, 홈과 시작 화면에 버튼에 대한 애니메이션을 추가하였습니다. 