### PR TITLE
feat : 프로필 이미지 크기 및 간격 조정

### DIFF
--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -422,7 +422,7 @@ onMounted(() => {
     z-index: 10;
     position: relative;
     overflow: hidden;
-    gap: 50px;
+    gap: 20px;
     transition: all 0.3s ease-in-out;
 }
 
@@ -441,7 +441,7 @@ onMounted(() => {
 }
 
 .profile-pic {
-    width: 50%;
+    width: 70%;
     border-radius: 50%;
     border: 3px solid #ffab91;
     margin-bottom: 5px;
@@ -507,7 +507,7 @@ onMounted(() => {
 }
 
 .nickname {
-    margin-bottom: 0;
+    margin-bottom: 10px;
 }
 
 /* 정보 컨테이너 */
@@ -545,9 +545,9 @@ onMounted(() => {
   position: relative;
   grid-column: span 2;
   width: auto;   
-  height: 50px; 
+  height: 0px;
   border-radius: 15px;
-  padding: 10px;  
+  padding: 10px;
 }
 .info-container {
   position: relative; 


### PR DESCRIPTION
## 연관된 이슈

> #17 

## 작업 내용

- 프로필 사진의 크기를 키우고, 경험치 정보와의 gap을 줄여서 가독성을 높였습니다.

### 스크린샷 (선택)
### 이전
![스크린샷 2024-11-15 144149](https://github.com/user-attachments/assets/b38d92e8-f74e-4093-9440-516b2226b00c)

### 현재
![스크린샷 2024-11-15 144204](https://github.com/user-attachments/assets/73a11cea-930a-4944-9dc1-a46893bbe2e6)