### PR TITLE
게임 화면 업그레이드

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "him-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "axios": "^1.7.7",
         "pinia": "^2.2.6",
         "pixi.js": "^8.5.2",
         "vue": "^3.5.12",
@@ -873,11 +874,49 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/earcut": {
       "version": "2.2.4",
@@ -948,6 +987,40 @@
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "license": "MIT"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -976,6 +1049,27 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/nanoid": {
@@ -1104,6 +1198,12 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.24.4",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "axios": "^1.7.7",
     "pinia": "^2.2.6",
     "pixi.js": "^8.5.2",
     "vue": "^3.5.12",

--- a/src/components/FailScreen.vue
+++ b/src/components/FailScreen.vue
@@ -2,6 +2,10 @@
   <div>
     <div id="game-over-overlay" v-if="isGameOver">
       <div id="game-over-text">GAME OVER</div>
+      <div class="game-info">
+        <p>운동 종류: {{ gameStore.typeString }}</p>
+        <div>난이도: {{ gameStore.gameDifficultyLevel }}</div>
+      </div>
       <div id="retry-message">다시 도전하려면 아래 버튼을 눌러주세요.</div>
       <button class="retry-button" @click="retryGame">다시하기</button>
       <button class="new-challenge-button" @click="newGame">새로운 게임하기</button>
@@ -10,30 +14,27 @@
 </template>
 
 <script setup>
-import { ref } from 'vue';
-import { useRouter, useRoute } from 'vue-router';
+import { useGameStore } from '@/stores/game';
+import { useRouter } from 'vue-router';
+
+const gameStore = useGameStore();
 
 const router = useRouter();
-const route = useRoute();
-
-const gameStarted = ref(false);
-const isGameOver = ref(true);
 
 const newGame = () => {
-  isGameOver.value = false;
   router.push({ name: 'GameSelectView' });
 };
 
 const retryGame = () => {
-  isGameOver.value = false;
-  gameStarted.value = false;
   router.push({
-        name: 'GamePlayView',
-        query: {
-            type: route.query.type,
-            level: route.query.level
-        }
-    });
+    name: 'GamePlayView',
+    state: {
+      id: gameStore.gameId,
+      type: gameStore.gameType,
+      difficultyLevel: gameStore.gameDifficultyLevel,
+      userId: gameStore.gameUserId
+    }
+  });
 };
 </script>
 

--- a/src/components/FailScreen.vue
+++ b/src/components/FailScreen.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div id="game-over-overlay" v-if="isGameOver">
+    <div id="game-over-overlay">
       <div id="game-over-text">GAME OVER</div>
       <div class="game-info">
         <p>운동 종류: {{ gameStore.typeString }}</p>
@@ -64,9 +64,15 @@ const retryGame = () => {
   animation: shake 0.5s ease-in-out infinite alternate, fadeIn 1.5s ease-in-out;
 }
 
+.game-info {
+    font-size: 1.5rem;
+    color: #aaaaaa;
+    text-align: center;
+}
+
 #retry-message {
   font-size: 1.5rem;
-  margin-top: 50px;
+  margin-top: 30px;
   color: #ff8080;
   animation: fadeIn 1.5s ease-in-out;
 }

--- a/src/components/SuccessScreen.vue
+++ b/src/components/SuccessScreen.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <div id="success-overlay" v-if="isGameSuccess">
+        <div id="success-overlay">
             <div id="success-text">SUCCESS!</div>
             <div class="game-info">
                 <p>운동 종류: {{ gameStore.typeString }}</p>
@@ -22,7 +22,7 @@
                 이미 성공한 게임이므로 경험치가 추가되지 않습니다.
             </div>
 
-            <button class="new-challenge-button" @click="newGame">새로운 챌린지하기</button>
+            <button class="new-challenge-button" @click="newGame">새로운 게임하기</button>
 
             <div v-for="firework in fireworks" :key="firework.id" class="firework"
                 :style="{ left: firework.left + '%', top: firework.top + '%', backgroundColor: firework.color }">
@@ -45,7 +45,6 @@ const router = useRouter();
 const curTierIcon = ref(curTierImage)
 const nextTierIcon = ref(nextTierImage)
 
-const isGameSuccess = ref(true);
 const fireworks = ref([]);
 const currentExp = ref(300);
 const addedExp = ref(gameStore.gameExpPoints);
@@ -89,7 +88,6 @@ onMounted(() => {
 });
 
 const newGame = () => {
-    isGameSuccess.value = false;
     router.push({ name: 'GameSelectView' });
 };
 
@@ -176,6 +174,12 @@ const addedExpString = computed(() => `+${addedExp.value} EXP!`);
     filter: blur(8px);
     transform: translateX(-100%);
     animation: shine 2s infinite linear;
+}
+
+.game-info {
+    font-size: 1.5rem;
+    color: #7a7878;
+    text-align: center;
 }
 
 @keyframes expIncrease {
@@ -282,7 +286,7 @@ const addedExpString = computed(() => `+${addedExp.value} EXP!`);
 
 .new-challenge-button {
     font-family: 'HakgyoansimDunggeunmisoTTF-B';
-    margin-top: 80px;
+    margin-top: 30px;
     padding: 20px 40px;
     background-color: #4CAF50;
     border: none;
@@ -302,38 +306,39 @@ const addedExpString = computed(() => `+${addedExp.value} EXP!`);
 }
 
 @keyframes jittery {
-  5%,
-  50% {
-    transform: scale(1);
-  }
 
-  10% {
-    transform: scale(0.9);
-  }
+    5%,
+    50% {
+        transform: scale(1);
+    }
 
-  15% {
-    transform: scale(1.15);
-  }
+    10% {
+        transform: scale(0.9);
+    }
 
-  20% {
-    transform: scale(1.15) rotate(-5deg);
-  }
+    15% {
+        transform: scale(1.15);
+    }
 
-  25% {
-    transform: scale(1.15) rotate(5deg);
-  }
+    20% {
+        transform: scale(1.15) rotate(-5deg);
+    }
 
-  30% {
-    transform: scale(1.15) rotate(-3deg);
-  }
+    25% {
+        transform: scale(1.15) rotate(5deg);
+    }
 
-  35% {
-    transform: scale(1.15) rotate(2deg);
-  }
+    30% {
+        transform: scale(1.15) rotate(-3deg);
+    }
 
-  40% {
-    transform: scale(1.15) rotate(0);
-  }
+    35% {
+        transform: scale(1.15) rotate(2deg);
+    }
+
+    40% {
+        transform: scale(1.15) rotate(0);
+    }
 }
 
 .exp-value {
@@ -401,5 +406,11 @@ const addedExpString = computed(() => `+${addedExp.value} EXP!`);
         opacity: 0;
         transform: translate(-50%, -30px);
     }
+}
+
+.no-exp-message {
+    font-size: 1.5rem;
+    color: #7a7878;
+    text-align: center;
 }
 </style>

--- a/src/components/SuccessScreen.vue
+++ b/src/components/SuccessScreen.vue
@@ -2,6 +2,10 @@
     <div>
         <div id="success-overlay" v-if="isGameSuccess">
             <div id="success-text">SUCCESS!</div>
+            <div class="game-info">
+                <p>운동 종류: {{ gameStore.typeString }}</p>
+                <div>난이도: {{ gameStore.gameDifficultyLevel }}</div>
+            </div>
             <div id="celebration-message">축하합니다! 목표를 달성했습니다!</div>
 
             <div class="exp-tier-container">
@@ -12,7 +16,11 @@
                 <img class="exp-tier-pic" :src="nextTierIcon" alt="다음 티어 사진" />
             </div>
 
-            <div class="exp-value" :style="{ '--total-exp': `'${addedExpString}'` }">현재 경험치: {{ expValue }} EXP</div>
+            <div class="exp-value" :style="addedExp !== 0 ? { '--total-exp': `'${addedExpString}'` } : {}">현재 경험치: {{
+                expValue }} EXP</div>
+            <div v-if="addedExp === 0" class="no-exp-message">
+                이미 성공한 게임이므로 경험치가 추가되지 않습니다.
+            </div>
 
             <button class="new-challenge-button" @click="newGame">새로운 챌린지하기</button>
 

--- a/src/components/SuccessScreen.vue
+++ b/src/components/SuccessScreen.vue
@@ -28,6 +28,9 @@ import { ref, onMounted, watch, computed } from 'vue';
 import { useRouter } from 'vue-router';
 import curTierImage from '@/assets/images/tier/tier_IRON.png';
 import nextTierImage from '@/assets/images/tier/tier_BRONZE.png';
+import { useGameStore } from '@/stores/game';
+
+const gameStore = useGameStore();
 
 const router = useRouter();
 
@@ -37,7 +40,7 @@ const nextTierIcon = ref(nextTierImage)
 const isGameSuccess = ref(true);
 const fireworks = ref([]);
 const currentExp = ref(300);
-const addedExp = ref(200);
+const addedExp = ref(gameStore.gameExpPoints);
 const targetExp = ref(1000);
 const expValue = ref(currentExp.value);
 const expFilledBarWidth = ref((expValue.value / targetExp.value) * 100);

--- a/src/main.js
+++ b/src/main.js
@@ -1,10 +1,13 @@
 import { createApp } from 'vue';
+import { createPinia } from 'pinia'
+
 import App from './App.vue';
 import router from './router';
 import './assets/main.css';
 
 const app = createApp(App);
 
+app.use(createPinia())
 app.use(router);
 
 app.mount('#app');

--- a/src/stores/game.js
+++ b/src/stores/game.js
@@ -1,0 +1,74 @@
+import axios from "axios";
+import { defineStore } from "pinia"
+import { computed, ref } from "vue";
+
+const REST_API_URL = 'http://localhost:8080/api/game'
+
+export const useGameStore = defineStore(`game`, () => {
+    // states
+    const gameId = ref(-1);
+    const gameType = ref('');
+    const gameDifficultyLevel = ref('');
+    const gameUserId = ref(-1);
+    const gameExpPoints = ref(0);
+    const gameIsAchieved = ref(false);
+
+    // getters
+    const typeString = computed(() => {
+        return gameType.value === 'PUSHUP' ? 'Push Up' : 'Squat';
+    });
+
+    // actions
+    const createGame = async (type, difficultyLevel, userId) => {
+
+        console.log("game.js - type: " + type);
+        console.log("game.js - difficultyLevel: " + difficultyLevel);
+        console.log("game.js - userId: " + userId);
+        gameType.value = type;
+        gameDifficultyLevel.value = difficultyLevel;
+        gameUserId.value = userId;
+
+        try {
+            const response = await axios.post(REST_API_URL, {
+                type: gameType.value,
+                difficultyLevel: gameDifficultyLevel.value,
+                userId: gameUserId.value
+            });
+            console.log("game.js - 서버 응답: ", response.data);
+            gameId.value = response.data;
+        } catch (error) {
+            console.error("game.js - 에러 발생: ", error);
+        }
+    }
+
+    const achieveGame = async (id, isAchieved) => {
+        gameId.value = id;
+        gameIsAchieved.value = isAchieved;
+
+        console.log(isAchieved);
+
+        try {
+            const response = await axios.put(REST_API_URL, {
+                gameId: gameId.value,
+                isAchieved: gameIsAchieved.value
+            });
+            console.log("game.js - 서버 응답: ", response.data);
+            gameExpPoints.value = response.data;
+        } catch (error) {
+            console.error("game.js - 에러 발생: ", error);
+        }
+        
+    }
+
+    return {
+        gameId,
+        gameType,
+        gameDifficultyLevel,
+        gameUserId,
+        gameExpPoints,
+        gameIsAchieved,
+        typeString,
+        createGame,
+        achieveGame,
+     }
+})

--- a/src/views/GamePlayView.vue
+++ b/src/views/GamePlayView.vue
@@ -11,6 +11,10 @@
                     <div id="pixi-container"></div>
 
                     <div id="ui-container">
+                        <div class="game-info">
+                            <p>운동 종류: {{ gameStore.typeString }}</p>
+                            <p>난이도: {{ gameStore.gameDifficultyLevel }}</p>
+                        </div>
                         <div id="label-container">Prediction Label</div>
                         <div id="counter-container">Count: <span id="counter">{{ counter }}</span></div>
                     </div>

--- a/src/views/GamePlayView.vue
+++ b/src/views/GamePlayView.vue
@@ -41,7 +41,7 @@
 <script setup>
 import { useRouter } from 'vue-router';
 import { ref, onMounted, nextTick, onUnmounted } from 'vue';
-import { Application, Sprite, Assets, Text } from 'pixi.js';
+import { Application, Sprite, Assets } from 'pixi.js';
 import { getCounter, init as tmInit, stop as tmStop } from '@/utils/teachableMachineForGame';
 import { useGameStore } from '@/stores/game';
 
@@ -90,7 +90,20 @@ async function startPixiAndTM() {
         height: window.innerHeight,
         backgroundColor: 0x1099bb
     });
-    document.getElementById("pixi-container").appendChild(app.value.canvas);
+    
+    const pixiContainer = document.getElementById("pixi-container");
+    if (pixiContainer) {
+        pixiContainer.appendChild(app.value.canvas);
+    } else {
+        console.error("'pixi-container' 요소가 존재하지 않습니다.");
+        return;
+    }
+
+    const webcamContainer = document.getElementById("webcam-container");
+    if (!webcamContainer) {
+        console.error("'webcam-container' 요소가 존재하지 않습니다.");
+        return;
+    }
 
     const backgroundTexture = await Assets.load('/images/background/background3.png');
     const runnerTextures = [
@@ -137,7 +150,7 @@ async function startPixiAndTM() {
     async function updateCounter() {
         const newCounterValue = await getCounter();
         if (newCounterValue > counterValue && !isGameOver.value) {
-            runner.x = 100 + newCounterValue * 30;
+            runner.x = 100 + newCounterValue * 100;
         }
         counterValue = newCounterValue;
     }
@@ -191,7 +204,7 @@ async function startPixiAndTM() {
         }
     }
 
-    function success() {
+    async function success() {
         isSuccess.value = true;
         isFalling = false;
         runner.texture = runnerTextures[0];
@@ -254,8 +267,15 @@ function startCountdown() {
     countdownStep();
 }
 
-onMounted(() => {
+onMounted(async () => {
     startCountdown();
+
+    await nextTick();
+    try {
+        console.log("초기화 준비 완료");
+    } catch (error) {
+        console.error("init 함수 실행 중 오류 발생:", error);
+    }
 })
 </script>
 
@@ -442,5 +462,15 @@ onMounted(() => {
     100% {
         background-color: rgba(0, 0, 0, 0.8);
     }
+}
+
+.game-info {
+    font-size: 1.5rem;
+    color: #ffffff;
+    background-color: rgba(0, 0, 0, 0.7);
+    padding: 10px;
+    border-radius: 8px;
+    margin-bottom: 20px;
+    text-align: center;
 }
 </style>

--- a/src/views/GamePlayView.vue
+++ b/src/views/GamePlayView.vue
@@ -39,6 +39,9 @@ import { useRouter } from 'vue-router';
 import { ref, onMounted, nextTick, onUnmounted } from 'vue';
 import { Application, Sprite, Assets, Text } from 'pixi.js';
 import { getCounter, init as tmInit, stop as tmStop } from '@/utils/teachableMachineForGame';
+import { useGameStore } from '@/stores/game';
+
+const gameStore = useGameStore();
 
 const router = useRouter();
 const isEndModalOpen = ref(false);
@@ -149,7 +152,22 @@ async function startPixiAndTM() {
         isGameOver.value = true;
         isFalling = true;
         runner.texture = runnerTextures[0];
-        router.push({ name: 'FailScreen' });
+
+        console.log("FailScreen - gameId: ", gameStore.gameId);
+        console.log("FailScreen - gameType: ", gameStore.gameType);
+        console.log("FailScreen - gameDifficultyLevel: ", gameStore.gameDifficultyLevel);
+        console.log("FailScreen - gameUserId: ", gameStore.gameUserId);
+
+        tmStop();
+        router.push({
+            name: 'FailScreen',
+            state: {
+                id: gameStore.gameId,
+                type: gameStore.gameType,
+                difficultyLevel: gameStore.gameDifficultyLevel,
+                userId: gameStore.userId
+            }
+        });
     }
 
     function makeRunnerFall() {
@@ -174,7 +192,26 @@ async function startPixiAndTM() {
         isFalling = false;
         runner.texture = runnerTextures[0];
         stopRunnerOnSuccess();
-        router.push({ name: 'SuccessScreen' });
+
+        await gameStore.achieveGame(gameStore.gameId, isSuccess.value);
+
+        console.log("SuccessScreen - gameId: ", gameStore.gameId);
+        console.log("SuccessScreen - gameType: ", gameStore.gameType);
+        console.log("SuccessScreen - gameDifficultyLevel: ", gameStore.gameDifficultyLevel);
+        console.log("SuccessScreen - gameExpPoints: ", gameStore.gameExpPoints);
+        console.log("SuccessScreen - gameUserId: ", gameStore.gameUserId);
+
+        tmStop();
+        router.push({ 
+            name: 'SuccessScreen',
+            state: {
+                id: gameStore.gameId,
+                type: gameStore.gameType,
+                difficultyLevel: gameStore.gameDifficultyLevel,
+                expPoints: gameStore.gameExpPoints,
+                userId: gameStore.gameUserId
+            }
+        });
     }
 
     function stopRunnerOnSuccess() {

--- a/src/views/GameSelectView.vue
+++ b/src/views/GameSelectView.vue
@@ -68,16 +68,6 @@ const selectedLevel = ref(null);
 const selectType = (type) => { selectedType.value = type; };
 const selectLevel = (level) => { selectedLevel.value = level; };
 
-const startGame = () => {
-    if (selectedType.value && selectedLevel.value) {
-        router.push({
-            name: 'GamePlayView',
-            query: {
-                type: selectedType.value,
-                level: selectedLevel.value
-            }
-        });
-    }
 const startGame = async () => {
     await gameStore.createGame(selectedType.value, selectedLevel.value, 1);
     router.push({

--- a/src/views/GameSelectView.vue
+++ b/src/views/GameSelectView.vue
@@ -1,16 +1,18 @@
 <template>
-    <div>
-        <div class="main-container">
+    <div class="container">
+        <div class="box box1"></div>
+
+        <div class="box box2 main-container">
             <div class="header">게임을 선택해주세요!</div>
 
             <div class="option-container">
-                <div class="option-card square" @click="selectType('Push Up')"
-                    :class="{ selected: selectedType === 'Push Up' }">
+                <div class="option-card square" @click="selectType('PUSHUP')"
+                    :class="{ selected: selectedType === 'PUSHUP' }">
                     <div class="option-icon">💪</div>
                     <div class="choice-label">Push Up</div>
                 </div>
-                <div class="option-card square" @click="selectType('Squat')"
-                    :class="{ selected: selectedType === 'Squat' }">
+                <div class="option-card square" @click="selectType('SQUAT')"
+                    :class="{ selected: selectedType === 'SQUAT' }">
                     <div class="option-icon">🏋️‍♂️</div>
                     <div class="choice-label">Squat</div>
                 </div>
@@ -34,17 +36,52 @@
                 </div>
             </div>
 
-            <button @click="startGame"
-                    class="custom-button"
-                    :style="{ animation: (!selectedType || !selectedLevel) ? 'jittery 4s infinite' : '' }"
-                    :disabled="!selectedType || !selectedLevel">
+            <button @click="startGame" class="custom-button"
+                :style="{ animation: (!selectedType || !selectedLevel) ? 'jittery 4s infinite' : '' }"
+                :disabled="!selectedType || !selectedLevel">
                 <span>시작하기</span>
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="4"
-                width="130" height="130" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" width="80" height="80" d="M9 5l7 7-7 7" />
+                    stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
                 </svg>
             </button>
+        </div>
 
+        <div class="box box3">
+            <div class="exp-info-container">
+                <div class="exp-detail-info-container">
+                    <div class="info-container">
+                        <img src="@/assets/images/icon/info-icon.png" @click="toggleInfo" class="info-icon">
+                        <div v-if="showInfo" class="info-popup">
+                            <p class="info-title">[오늘의 게임]</p>
+                            <p>오늘 성취한 게임(✔️)과 <br> 도전하지 않은 게임(⏳) <br> 목록입니다.</p>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="exp-card">
+                    <h5 class="info-section">
+                        Push Up
+                    </h5>
+                    <ul class="list-unstyled">
+                        <li class="list pending">Easy: 5 exp</li>
+                        <li class="list completed">Medium: 10 exp</li>
+                        <li class="list completed">Hard: 20 exp</li>
+                    </ul>
+                </div>
+
+                <div class="exp-card">
+                    <h5 class="info-section">
+                        Squat
+                    </h5>
+                    <ul class="list-unstyled">
+                        <li class="list completed">Easy: 5 exp</li>
+                        <li class="list completed">Medium: 10 exp</li>
+                        <li class="list pending">Hard: 20 exp</li>
+                    </ul>
+                </div>
+
+            </div>
         </div>
 
         <div v-for="(icon, index) in floatingIcons" :key="index" class="floating-icon"
@@ -61,6 +98,8 @@ import { useGameStore } from '@/stores/game';
 
 const router = useRouter();
 const gameStore = useGameStore();
+
+const showInfo = ref(false);
 
 const selectedType = ref(null);
 const selectedLevel = ref(null);
@@ -80,6 +119,9 @@ const startGame = async () => {
         }
     });
 };
+
+const toggleInfo = () => {
+    showInfo.value = !showInfo.value;
 };
 
 const floatingIcons = ref([]);
@@ -101,6 +143,33 @@ onMounted(addFloatingIcons);
 </script>
 
 <style scoped>
+.container {
+    display: flex;
+    width: 100vw;
+    height: 100vh;
+    justify-content: space-around;
+    align-items: center;
+    padding: 20px;
+    box-sizing: border-box;
+}
+
+.box {
+    color: white;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 24px;
+    height: 70%;
+}
+
+.box1 {
+    flex: 1;
+}
+
+.box2 {
+    flex: 2;
+}
+
 .main-container {
     display: flex;
     flex-direction: column;
@@ -232,7 +301,8 @@ onMounted(addFloatingIcons);
     display: flex;
     align-items: center;
     justify-content: flex-end;
-    padding: 12px 15px;
+    padding: 15px 20px;
+    padding-left: 70px;
     background-color: #ff7043;
     border: 4px solid #d95c37;
     border-radius: 9999px;
@@ -245,8 +315,8 @@ onMounted(addFloatingIcons);
 }
 
 .custom-button svg {
-    width: 30%;
-    height: 20%;
+    width: 75px;
+    height: 75px;
 }
 
 .custom-button span {
@@ -266,38 +336,39 @@ onMounted(addFloatingIcons);
 }
 
 @keyframes jittery {
-  5%,
-  50% {
-    transform: scale(1);
-  }
 
-  10% {
-    transform: scale(0.9);
-  }
+    5%,
+    50% {
+        transform: scale(1);
+    }
 
-  15% {
-    transform: scale(1.15);
-  }
+    10% {
+        transform: scale(0.9);
+    }
 
-  20% {
-    transform: scale(1.15) rotate(-5deg);
-  }
+    15% {
+        transform: scale(1.15);
+    }
 
-  25% {
-    transform: scale(1.15) rotate(5deg);
-  }
+    20% {
+        transform: scale(1.15) rotate(-5deg);
+    }
 
-  30% {
-    transform: scale(1.15) rotate(-3deg);
-  }
+    25% {
+        transform: scale(1.15) rotate(5deg);
+    }
 
-  35% {
-    transform: scale(1.15) rotate(2deg);
-  }
+    30% {
+        transform: scale(1.15) rotate(-3deg);
+    }
 
-  40% {
-    transform: scale(1.15) rotate(0);
-  }
+    35% {
+        transform: scale(1.15) rotate(2deg);
+    }
+
+    40% {
+        transform: scale(1.15) rotate(0);
+    }
 }
 
 .floating-icon {
@@ -315,6 +386,152 @@ onMounted(addFloatingIcons);
 
     100% {
         transform: translateY(-30px);
+    }
+}
+
+.box3 {
+    flex: 1;
+    display: flex;
+    align-items: flex-start;
+    justify-content: flex-start;
+}
+
+.exp-info-container {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    border-radius: 20px;
+    color: #333;
+    gap: 20px;
+    width: 95%;
+    height: 40%;
+    padding: 10px;
+    overflow: auto;
+    z-index: 10;
+}
+
+.exp-detail-info-container {
+    position: relative;
+    grid-column: span 2;
+    width: auto;
+    height: 0px;
+    border-radius: 15px;
+    gap: 0px;
+}
+
+.info-container {
+    position: relative;
+    display: inline-block;
+    z-index: 100;
+}
+
+.info-icon {
+    cursor: pointer;
+    font-size: 20%;
+    height: 20px;
+    width: 20px;
+}
+
+.info-title {
+    color: #e74c3c;
+    font-weight: bold;
+}
+
+.info-popup {
+    position: absolute;
+    top: 70%;
+    left: 10%;
+    margin-top: 8px;
+    padding: 12px;
+    width: 220px;
+    background-color: #ffffff;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+    z-index: 9999;
+    font-size: 0.9rem;
+    text-align: center;
+}
+
+.exp-card {
+    background-color: #ffffff;
+    border-radius: 15px;
+    padding: 10px;
+    box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.5);
+    transition: transform 0.3s, box-shadow 0.3s;
+    font-size: 1rem;
+    color: #444;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: center;
+}
+
+.exp-card:hover {
+    transform: scale(1.05);
+    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.15);
+}
+
+.info-section {
+    margin-top: 10px;
+    margin-bottom: 10px;
+    font-size: 1.5em;
+    color: #444;
+    text-align: center;
+    display: inline-flex;
+    align-items: center;
+}
+
+.list-unstyled {
+    list-style: none;
+    padding-left: 0;
+}
+
+.list {
+    font-size: 1.1em;
+    margin-bottom: 10px;
+    display: flex;
+    align-items: center;
+}
+
+.list.completed {
+    color: #707974;
+    position: relative;
+}
+
+.list.completed::before {
+    content: '✔️';
+}
+
+.list.pending {
+    font-weight: bold;
+    color: #e64201;
+    position: relative;
+}
+
+.list.pending::before {
+    content: '⏳';
+}
+
+.highlight,
+.time-remaining {
+    animation: bounce 1s ease-in-out infinite alternate;
+}
+
+.list.pending {
+    animation: shake 1s ease-in-out infinite alternate;
+}
+
+@keyframes shake {
+    0% {
+        transform: translate(0, 0);
+    }
+
+    50% {
+        transform: translate(5px, 0);
+    }
+
+    100% {
+        transform: translate(0, 0);
     }
 }
 </style>

--- a/src/views/GameSelectView.vue
+++ b/src/views/GameSelectView.vue
@@ -57,8 +57,10 @@
 <script setup>
 import { ref, onMounted } from 'vue';
 import { useRouter } from 'vue-router';
+import { useGameStore } from '@/stores/game';
 
 const router = useRouter();
+const gameStore = useGameStore();
 
 const selectedType = ref(null);
 const selectedLevel = ref(null);
@@ -76,6 +78,18 @@ const startGame = () => {
             }
         });
     }
+const startGame = async () => {
+    await gameStore.createGame(selectedType.value, selectedLevel.value, 1);
+    router.push({
+        name: 'GamePlayView',
+        state: {
+            id: gameStore.gameId,
+            type: gameStore.gameType,
+            difficultyLevel: gameStore.gameDifficultyLevel,
+            userId: gameStore.gameUserId
+        }
+    });
+};
 };
 
 const floatingIcons = ref([]);

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -15,8 +15,9 @@
                         <div class="modal-content">
                             <h3>프로필 이미지 선택</h3>
                             <div class="image-grid">
-                            <img v-for="(image, index) in availableImages" :key="index" :src="image" @click="selectProfileImage(image)" 
-                                class="profile-image-option" :alt="`프로필 이미지 ${index + 1}`" />
+                                <img v-for="(image, index) in availableImages" :key="index" :src="image"
+                                    @click="selectProfileImage(image)" class="profile-image-option"
+                                    :alt="`프로필 이미지 ${index + 1}`" />
                             </div>
                             <button @click="closeImageSelection" class="close-button">닫기</button>
                         </div>
@@ -29,21 +30,21 @@
             <div class="exp-info-container">
                 <div class="exp-detail-info-container">
                     <div class="info-container">
-                    <img src="@/assets/images/icon/info-icon.png" @click="toggleInfo" class="info-icon">
-                    <div v-if="showInfo" class="info-popup">
-                    <p class="info-title">[오늘의 경험치]</p>
-                    <p>- 오늘 받을 수 있는 최대 경험치와 내가 오늘 받은 경험치가 표시됩니다.</p>
-                    <p class="info-title">[챌린지 경험치]</p>
-                    <p>- 챌린지와 게임 성공 시, 아이콘이 ✔️로 변경되며 경험치가 주어집니다.</p>
-                    <p>- 아직 진행하지 않은 챌린지나 게임의 경우, 아이콘이 ⏳으로 표시됩니다.</p>
-                    <p class="info-title">[패널티 경험치]</p>
-                    <p>- 챌린지를 진행하지 않으면 패널티를 받을 수 있습니다.</p>
-                    <p class="info-title">[보너스 경험치]</p>
-                    <p>- 진행 중인 챌린지를 매일 연속하여 진행하면 보너스 경험치가 주어집니다.</p>
+                        <img src="@/assets/images/icon/info-icon.png" @click="toggleInfo" class="info-icon">
+                        <div v-if="showInfo" class="info-popup">
+                            <p class="info-title">[오늘의 경험치]</p>
+                            <p>- 오늘 받을 수 있는 최대 경험치와 내가 오늘 받은 경험치가 표시됩니다.</p>
+                            <p class="info-title">[챌린지 경험치]</p>
+                            <p>- 챌린지와 게임 성공 시, 아이콘이 ✔️로 변경되며 경험치가 주어집니다.</p>
+                            <p>- 아직 진행하지 않은 챌린지나 게임의 경우, 아이콘이 ⏳으로 표시됩니다.</p>
+                            <p class="info-title">[패널티 경험치]</p>
+                            <p>- 챌린지를 진행하지 않으면 패널티를 받을 수 있습니다.</p>
+                            <p class="info-title">[보너스 경험치]</p>
+                            <p>- 진행 중인 챌린지를 매일 연속하여 진행하면 보너스 경험치가 주어집니다.</p>
+                        </div>
                     </div>
                 </div>
-                </div> 
-                
+
                 <div class="exp-card">
                     <h5 class="info-section">
                         승급 필요 경험치
@@ -151,7 +152,16 @@
                 </div>
 
                 <div class="box3-and-buttons">
-                    <div class="box box3">박스3</div>
+                    <div class="box box3 tier-container">
+                        <h5 class="info-section">
+                            예시
+                        </h5>
+                        <ul class="list-unstyled">
+                            <li class="list completed">Easy: 5 exp</li>
+                            <li class="list completed">Medium: 10 exp</li>
+                            <li class="list pending">Hard: 20 exp</li>
+                        </ul>
+                    </div>
 
                     <div class="button-container">
                         <button @click="startChallenge" class="custom-button">
@@ -203,7 +213,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, watch } from 'vue';
+import { ref, onMounted, watch } from 'vue';
 import { useRouter } from 'vue-router';
 
 import bearImage from '@/assets/images/character/character_BEAR.png';
@@ -231,7 +241,7 @@ const router = useRouter();
 const showInfo = ref(false);
 
 const toggleInfo = () => {
-  showInfo.value = !showInfo.value;
+    showInfo.value = !showInfo.value;
 };
 
 const isImageSelectionOpen = ref(false);
@@ -244,8 +254,8 @@ const openImageSelection = () => { isImageSelectionOpen.value = true; };
 const closeImageSelection = () => { isImageSelectionOpen.value = false; };
 
 const selectProfileImage = (image) => {
-  user.value.profilePic = image;
-  closeImageSelection();
+    user.value.profilePic = image;
+    closeImageSelection();
 };
 
 const showRankings = ref(false);
@@ -309,10 +319,10 @@ watch(expValue, (newVal) => {
 });
 
 const startChallenge = () => {
-  router.push({ name: 'ChallengeSelectView' });
+    router.push({ name: 'ChallengeSelectView' });
 };
 const startGame = () => {
-  router.push({ name : 'GameSelectView' })  
+    router.push({ name: 'GameSelectView' })
 };
 
 const currentMonth = ref(new Date().getMonth() + 1);
@@ -395,9 +405,6 @@ onMounted(() => {
 
 /* ===================================================== */
 .box {
-    border: 2px solid white;
-    background-color: #333;
-    color: white;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -464,40 +471,41 @@ onMounted(() => {
 }
 
 .modal-content {
-  background-color: #d2d0d0;
-  color: #282626;
-  border-radius: 8px;
-  padding: 20px;
-  width: 300px;
-  text-align: center;
+    background-color: #d2d0d0;
+    color: #282626;
+    border-radius: 8px;
+    padding: 20px;
+    width: 300px;
+    text-align: center;
 }
 
 .profile-image-option {
-  width: 80px;
-  height: 80px;
-  cursor: pointer;
-  border-radius: 50%;
-  border: 2px solid transparent;
-  transition: border-color 0.3s;
+    width: 80px;
+    height: 80px;
+    cursor: pointer;
+    border-radius: 50%;
+    border: 2px solid transparent;
+    transition: border-color 0.3s;
 }
 
 .profile-image-option:hover {
-  border-color: #d8854e;
+    border-color: #d8854e;
 }
 
 .close-button {
-  background-color: #ff7043;
-  color: #fff;
-  padding: 8px 16px;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
+    background-color: #ff7043;
+    color: #fff;
+    padding: 8px 16px;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
 }
+
 .current-profile-image {
-  width: 100px;
-  height: 100px;
-  border-radius: 50%;
-  margin-top: 20px;
+    width: 100px;
+    height: 100px;
+    border-radius: 50%;
+    margin-top: 20px;
 }
 
 
@@ -532,8 +540,10 @@ onMounted(() => {
     color: #444;
     display: flex;
     flex-direction: column;
-    justify-content: center;
+    justify-content: flex-start;
     align-items: center;
+    overflow-y: auto;
+    max-height: 200px;
 }
 
 .exp-card:hover {
@@ -542,40 +552,41 @@ onMounted(() => {
 }
 
 .exp-detail-info-container {
-  position: relative;
-  grid-column: span 2;
-  width: auto;   
-  height: 0px;
-  border-radius: 15px;
-  padding: 10px;
+    position: relative;
+    grid-column: span 2;
+    width: auto;
+    height: 0px;
+    border-radius: 15px;
+    padding: 10px;
 }
+
 .info-container {
-  position: relative; 
-  left: 45%; 
-  top: 75%;
-  display: inline-block;
-  z-index: 100;  
+    position: relative;
+    left: 45%;
+    top: 75%;
+    display: inline-block;
+    z-index: 100;
 }
 
 .info-icon {
-  cursor: pointer;
-  font-size: 20%;
+    cursor: pointer;
+    font-size: 20%;
 }
 
 .info-popup {
-  position: absolute;
-  top: 100%;
-  left: 10%;
-  transform: translateX(-80%);
-  margin-top: 8px;
-  padding: 12px;
-  width: 220px;
-  background-color: #ffffff;
-  border: 1px solid #ccc;
-  border-radius: 8px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-  z-index: 9999;
-  font-size: 0.9rem;
+    position: absolute;
+    top: 100%;
+    left: 10%;
+    transform: translateX(-80%);
+    margin-top: 8px;
+    padding: 12px;
+    width: 220px;
+    background-color: #ffffff;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+    z-index: 9999;
+    font-size: 0.9rem;
 }
 
 
@@ -684,7 +695,7 @@ onMounted(() => {
 
 .penalty-highlight,
 .list.pending {
-    animation: shake 1s ease-in-out infinite alternate, fadeIn 1.5s ease-in-out;
+    animation: shake 1s ease-in-out infinite alternate;
 }
 
 @keyframes bounce {
@@ -717,7 +728,7 @@ onMounted(() => {
 .right-section {
     display: flex;
     flex-direction: column;
-    flex: 1;
+    flex: 1.2;
     gap: 20px;
     transition: all 0.3s ease-in-out;
 }
@@ -733,7 +744,7 @@ onMounted(() => {
 
 /* 티어 정보 */
 .tier-container {
-    flex: 0.6;
+    flex: 0.5;
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -785,8 +796,8 @@ onMounted(() => {
 }
 
 .info-title {
-  color: #e74c3c;
-  font-weight: bold;
+    color: #e74c3c;
+    font-weight: bold;
 }
 
 .exp-tier-container {
@@ -829,7 +840,6 @@ onMounted(() => {
     text-align: center;
 }
 
-/* 티어 정보 섹션 */
 .rankings-container {
     display: flex;
     flex-direction: column;
@@ -947,7 +957,7 @@ onMounted(() => {
     flex-direction: column;
     justify-content: center;
     z-index: 10;
-    gap: 30px;
+    gap: 20px;
     transition: all 0.3s ease-in-out;
 }
 
@@ -956,12 +966,12 @@ onMounted(() => {
     display: flex;
     align-items: center;
     justify-content: flex-end;
-    padding: 12px 15px;
+    padding: 0px 15px;
     background-color: #ff7043;
     border: 4px solid #d95c37;
     border-radius: 9999px;
     color: white;
-    font-size: 1.7rem;
+    font-size: 2rem;
     font-weight: bold;
     cursor: pointer;
 }
@@ -984,7 +994,7 @@ onMounted(() => {
 
 /* 캘린더 */
 .calendar {
-    flex: 2.5;
+    flex: 3;
     display: flex;
     flex-direction: column;
     background: #fff;


### PR DESCRIPTION
## 연관된 이슈

> #41 

## 작업 내용

- 사용자에게 정보 전달 기능을 강화합니다.
- 사용자가 완료한 게임과 도전이 필요한 게임에 대한 목록을 게임 선택 화면에서 제공합니다.
- 사용자가 현재 어떤 게임을 하고 있는지를 알 수 있도록, 게임 플레이 화면과 성공/실패 화면에 보여줍니다.
- 사용자의 안전성을 보장하기 위해 게임 종료 시, 웹캠을 종료합니다.

### 스크린샷 (선택)
### 게임 선택 화면
![스크린샷 2024-11-16 223912](https://github.com/user-attachments/assets/d9ed9afa-e403-41a6-8adf-8e7564aff392)

### 게임 플레이 화면
![스크린샷 2024-11-16 213115](https://github.com/user-attachments/assets/de9ff6ee-c1fa-41dd-917a-6d402903ba1e)

### 게임 성공 화면
![스크린샷 2024-11-16 213152](https://github.com/user-attachments/assets/6f527bfa-13c0-42f2-8592-4ad055240a1d)

### 게임 실패 화면
![스크린샷 2024-11-16 213123](https://github.com/user-attachments/assets/af3d78e4-12cc-4162-a725-8ed23ea620b3)

### 홈 화면 (임시)
![스크린샷 2024-11-16 213218](https://github.com/user-attachments/assets/e3b219f4-670e-4864-ad54-e687db43b541)

## 리뷰 요구사항 (선택)

### 1. 홈 화면
- 홈 화면의 경우, 게임은 운동 타입과 난이도에 따라 게시판 내용이 달라집니다.
- 챌린지는 챌린지 제목에 따라 게시판 내용이 달라집니다.
- 따라서, 게임 경험치 정보를 두 개의 박스로 분리할지 아니면 스크롤 기능으로 대체할지 고민입니다.
- 임시로 박스3의 정보를 게시판으로 만들어보았는데, 활용성에 대해서 논의하면 좋을 것 같습니다.

### 2. 웹캠 종료 기능
- 추가적으로 챌린지의 경우, stop()메서드를 활용하여 챌린지 종료 후, 웹캠과 기타 티쳐블 머신 초기화를 진행해야합니다.
- 티쳐블 머신의 코드는 수정하였으나, Git 충돌 발생 우려로 챌린지 플레이 화면에서의 수정은 하지 않았습니다.
- 추후에 대면으로 만나 논의하면 좋을 것 같습니다.

### 3. 추가 기능 요구
- 챌린지 파트도 마찬가지로 정보 전달 기능을 강화하기 위해 다음 프로세스를 진행하면 좋을 것 같습니다.
a. 챌린지/게임 성공 화면 분리
b. ChallengeSelectView -> 성공한 챌린지 & 도전하지 않은 챌린지 제목 목록 제공
c. ChallengePlayView -> 도전 중인 챌린지 제목과 운동 타입, 목표 날짜, 목표 갯수 제공
d. SuccessScreen -> 성공한 챌린지 제목과 운동 타입, 목표 날짜, 목표 갯수 제공
   - 참고로, 챌린지는 실패 화면이 사용되지 않습니다.
   
### 유의사항
우선, 챌린지의 연동이 방대하기 때문에, api 연동 위주로 집중하여 빠르게 끝내고, 위 논의 사항들을 함께 진행할 것을 추천합니다.