### PR TITLE
회원가입/로그인/로그아웃 기능 구현

### DIFF
--- a/src/components/HeaderNav.vue
+++ b/src/components/HeaderNav.vue
@@ -36,7 +36,7 @@
       <div class="profile-button">
         <img :src=user.profileImg alt="Profile" class="profile-image">
         <div class="nickname">{{ user.nickname }}</div>
-        <RouterLink :to="{ name: 'StartView' }" class="logout-item">로그아웃</RouterLink>
+        <div @click="handleLogout" class="logout-item">로그아웃</div>
       </div>
     </div>
   </div>
@@ -49,15 +49,20 @@ import { useUserStore } from '@/stores/user';
 import { useAchievedExp } from "@/composables/useAchievedExp";
 import { useTodayChallengeStore } from '@/stores/todayChallenge';
 import { useGameStore } from '@/stores/game';
+import { useAuthStore } from "@/stores/auth";
+import { useRouter } from "vue-router";
 
 const todayChallengeStore = useTodayChallengeStore();
 const userStore = useUserStore();
 const gameStore = useGameStore();
+const authStore = useAuthStore();
+const router = useRouter();
 
 const { todayChallenges } = storeToRefs(todayChallengeStore);
 const { games } = storeToRefs(gameStore);
 const { userId } = storeToRefs(userStore);
 const { user } = storeToRefs(userStore);
+const { userInfo } = storeToRefs(authStore);
 
 const expByDifficulty = { "EASY": 5, "MEDIUM": 10, "HARD": 20 };
 
@@ -97,6 +102,15 @@ const startRolling = () => {
   setInterval(() => {
     currentIndex.value = (currentIndex.value + 1) % items.value.length;
   }, 2000);
+};
+
+const handleLogout = async () => {
+    try {
+        await authStore.logout(userInfo.value.email);
+        router.push({ name: "StartView" });
+    } catch (err) {
+        console.error("로그아웃 에러:", err);
+    }
 };
 
 onMounted(async() => {

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -1,0 +1,82 @@
+<template>
+    <div v-if="visible" class="modal-overlay">
+        <div class="modal-content">
+            <h3 class="modal-title">{{ title }}</h3>
+            <p class="modal-message">{{ message }}</p>
+            <button @click="closeModal" class="modal-button">닫기</button>
+        </div>
+    </div>
+</template>
+
+<script setup>
+defineProps({
+    visible: {
+        type: Boolean,
+        required: true,
+    },
+    title: {
+        type: String,
+        default: "알림",
+    },
+    message: {
+        type: String,
+        default: "",
+    },
+});
+
+const emit = defineEmits(["close"]);
+
+const closeModal = () => {
+    emit("close");
+};
+</script>
+
+<style scoped>
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.modal-content {
+    background: white;
+    padding: 20px;
+    border-radius: 10px;
+    text-align: center;
+    width: 300px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}
+
+.modal-title {
+    font-size: 1.5rem;
+    margin-bottom: 10px;
+}
+
+.modal-message {
+    font-size: 1rem;
+    margin-bottom: 20px;
+}
+
+.modal-button {
+    padding: 10px 20px;
+    background-color: #f33a3a;
+    color: white;
+    border: none;
+    border-radius: 5px;
+    font-size: 1.2rem;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+    font-family: 'HakgyoansimDunggeunmisoTTF-B';
+}
+
+.modal-button:hover {
+    background-color: #45a049;
+}
+</style>

--- a/src/plugins/setupAxios.js
+++ b/src/plugins/setupAxios.js
@@ -1,0 +1,47 @@
+import axios from "axios";
+
+export const setupAxiosInterceptors = (authStore, router) => {
+
+    const instance = axios.create({
+        baseURL: "http://localhost:8080/api",
+    });
+
+    instance.interceptors.request.use(
+        (config) => {
+            const token = localStorage.getItem("accessToken");
+            console.log(token);
+            if (token) {
+                config.headers["Authorization"] = `Bearer ${token}`;
+            } else {
+                console.warn("accessToken이 없습니다.");
+            }
+            return config;
+        },
+        (error) => {
+            return Promise.reject(error);
+        }
+    );
+
+    instance.interceptors.response.use(
+        (response) => {
+            const newAccessToken = response.headers["new-access-token"];
+            if (newAccessToken) {
+                localStorage.setItem("accessToken", newAccessToken);
+                console.log("새로운 Access Token이 업데이트되었습니다:", newAccessToken);
+            }
+            return response;
+        },
+        async (error) => {
+            if (error.response?.status === 401) {
+                console.warn("토큰이 만료되었습니다. StartView로 이동합니다.");
+                authStore.logout();
+                await router.push({ name: "StartView" });
+            }
+            return Promise.reject(error);
+        }
+    );
+    
+
+
+    return instance;
+};

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -24,12 +24,12 @@ const routes = [
     component: LoginView,
   },
   {
-    path: '/sign-up-view',
+    path: '/signup-view',
     name: 'SignUpView',
     component: SignUpView,
   },
   {
-    path: '/home-view',                              
+    path: '/home-view/:userId',                              
     name: 'HomeView',
     component: HomeView,
   },

--- a/src/stores/attendance.js
+++ b/src/stores/attendance.js
@@ -1,14 +1,18 @@
-import axios from "axios";
+import { setupAxiosInterceptors } from "@/plugins/setupAxios.js";
 import { defineStore } from "pinia";
 import { ref } from 'vue';
-
-const REST_API_URL = `http://localhost:8080/api/attendance`;
+import { useRouter } from "vue-router";
+import { useAuthStore } from "@/stores/auth"; 
 
 export const useAttendanceStore = defineStore('attendance', () => {
     const monthlyAttendance = ref([]);
 
+    const authStore = useAuthStore();
+    const router = useRouter();
+    const axiosInstance = setupAxiosInterceptors(authStore, router); 
+
     const setAttendanceStatus = (userId) => {
-        axios.get(`${REST_API_URL}/check/${userId}`)
+        axiosInstance.get(`/attendance/check/${userId}`)
         .then((response) => {
             console.log(response);
         })
@@ -18,7 +22,7 @@ export const useAttendanceStore = defineStore('attendance', () => {
     }
     
     const fetchMonthlyAttendance = async (userId, year, month) => {
-        await axios.get(`${REST_API_URL}/${userId}`, {
+        await axiosInstance.get(`/attendance/${userId}`, {
             params: { year, month }
         })
         .then((response) => {

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -1,0 +1,45 @@
+import axios from "axios";
+import { defineStore } from "pinia";
+import { ref } from 'vue';
+
+export const useAuthStore = defineStore('auth', () => {
+    const userInfo = ref({
+        email: "",
+        userId: null,
+        message: "",
+    });
+
+    const signupStatus = ref({
+        success: false,
+        message: "",
+        errorType: "",
+    });
+    const signUp = async (userData) => {
+        try {
+            await axiosInstance.post(`/auth/signup`, userData);
+            signupStatus.value.success = true;
+            signupStatus.value.message = "회원가입이 성공적으로 완료되었습니다!";
+            signupStatus.value.errorType = "";
+        } catch (err) {
+            signupStatus.value.success = false;
+
+            if (err.response?.status === 409) {
+                const errorMessage = err.response.data;
+                if (errorMessage.includes("닉네임")) {
+                    signupStatus.value.message = "닉네임이 중복됩니다. 다른 닉네임을 입력해주세요.";
+                    signupStatus.value.errorType = "nickname";
+                } else if (errorMessage.includes("이메일")) {
+                    signupStatus.value.message = "이메일이 중복됩니다. 다른 이메일을 입력해주세요.";
+                    signupStatus.value.errorType = "email";
+                }
+            } else {
+                signupStatus.value.message = "회원가입에 실패했습니다. 다시 시도해주세요.";
+                signupStatus.value.errorType = "general";
+            }
+        }
+    };
+    return {
+        signupStatus,
+        signUp,
+    };
+});

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -90,6 +90,24 @@ export const useAuthStore = defineStore('auth', () => {
             return false;
         }
     };
+
+    const logout = async (email) => {
+        try {
+            await axiosInstance.post(`/auth/logout`, { email });
+            console.log("로그아웃 성공");
+        } catch (err) {
+            console.error("로그아웃 실패:", err);
+        } finally {
+            localStorage.removeItem("accessToken");
+            userInfo.value = {
+                email: "",
+                userId: null,
+                message: "",
+            };
+            console.log("상태 초기화 완료");
+        }
+    };
+
     return {
         signupStatus,
         verificationStatus,
@@ -98,5 +116,6 @@ export const useAuthStore = defineStore('auth', () => {
         verifyCode,
         userInfo,
         login,
+        logout,
     };
 });

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -14,6 +14,16 @@ export const useAuthStore = defineStore('auth', () => {
         message: "",
         errorType: "",
     });
+
+    const verificationStatus = ref({
+        success: false,
+        message: "",
+    });
+
+    const axiosInstance = axios.create({
+        baseURL: "http://localhost:8080/api",
+    });
+
     const signUp = async (userData) => {
         try {
             await axiosInstance.post(`/auth/signup`, userData);
@@ -38,8 +48,34 @@ export const useAuthStore = defineStore('auth', () => {
             }
         }
     };
+
+    const sendVerificationCode = async (email) => {
+        try {
+            await axiosInstance.post(`/auth/send-verification-code`, { email });
+            verificationStatus.value.success = true;
+            verificationStatus.value.message = "인증코드가 발송되었습니다. 이메일을 확인해주세요.";
+        } catch (err) {
+            verificationStatus.value.success = false;
+            verificationStatus.value.message = "인증코드 발송에 실패했습니다. 다시 시도해주세요.";
+        }
+    };
+
+    const verifyCode = async (email, code) => {
+        try {
+            await axiosInstance.post(`/auth/verify-code`, { email, code });
+            verificationStatus.value.success = true;
+            verificationStatus.value.message = "인증이 성공적으로 완료되었습니다.";
+        } catch (err) {
+            verificationStatus.value.success = false;
+            verificationStatus.value.message = "인증에 실패했습니다. 다른 이메일을 사용해주세요.";
+        }
+    };
     return {
         signupStatus,
+        verificationStatus,
         signUp,
+        sendVerificationCode,
+        verifyCode,
+        userInfo,
     };
 });

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -70,6 +70,26 @@ export const useAuthStore = defineStore('auth', () => {
             verificationStatus.value.message = "인증에 실패했습니다. 다른 이메일을 사용해주세요.";
         }
     };
+
+    const login = async (email, password) => {
+        try {
+            const response = await axiosInstance.post(`/auth/login`, { email, password });
+            localStorage.setItem("accessToken", response.data.accessToken);
+            localStorage.setItem("userId", response.data.userId);
+
+            userInfo.value = {
+                email: response.data.email,
+                userId: response.data.userId,
+                message: response.data.message,
+            };
+
+            console.log("로그인 성공:", response.data.message);
+            return true;
+        } catch (err) {
+            console.error("로그인 실패:", err.response?.data?.message || "알 수 없는 오류");
+            return false;
+        }
+    };
     return {
         signupStatus,
         verificationStatus,
@@ -77,5 +97,6 @@ export const useAuthStore = defineStore('auth', () => {
         sendVerificationCode,
         verifyCode,
         userInfo,
+        login,
     };
 });

--- a/src/stores/challenge.js
+++ b/src/stores/challenge.js
@@ -1,15 +1,19 @@
-import axios from "axios";
+import { setupAxiosInterceptors } from "@/plugins/setupAxios.js";
 import { defineStore } from "pinia";
 import { ref } from 'vue';
-
-const REST_API_URL = `http://localhost:8080/api/challenge`;
+import { useRouter } from "vue-router";
+import { useAuthStore } from "@/stores/auth";
 
 export const useChallengeStore = defineStore('challenge', () => {
     const challenges = ref([]);
     const currentChallenge = ref(null);
+    
+    const authStore = useAuthStore();
+    const router = useRouter();
+    const axiosInstance = setupAxiosInterceptors(authStore, router);
 
     const fetchCurrentChallenge = (challengeId) => {
-        axios.get(`${REST_API_URL}/${challengeId}`)
+        axiosInstance.get(`/challenge/${challengeId}`)
         .then((response) => {
             currentChallenge.value = response.data;
         })
@@ -19,7 +23,7 @@ export const useChallengeStore = defineStore('challenge', () => {
     }
 
     const fetchChallenges = (userId, status) => {
-        axios.get(REST_API_URL, {
+        axiosInstance.get(`/challenge`, {
             params: { userId, status }
         })
         .then((response) => {
@@ -35,7 +39,7 @@ export const useChallengeStore = defineStore('challenge', () => {
     }
 
     const addChallenge = (challenge) => {
-        axios.post(REST_API_URL, challenge)
+        axiosInstance.post(`/challenge`, challenge)
         .then((response) => {
             console.log(response);
             challenges.value.push(response.data);
@@ -46,7 +50,7 @@ export const useChallengeStore = defineStore('challenge', () => {
     }
 
     const updateChallenge = (challengeId, challenge) => {
-        axios.put(`${REST_API_URL}/${challengeId}`, challenge)
+        axiosInstance.put(`/challenge/${challengeId}`, challenge)
         .then((response) => {
             console.log(response);
         })
@@ -56,7 +60,7 @@ export const useChallengeStore = defineStore('challenge', () => {
     }
 
     const deleteChallenge = (challengeId) => {
-        axios.delete(`${REST_API_URL}/${challengeId}`)
+        axiosInstance.delete(`/challenge/${challengeId}`)
         .then((response) => {
             console.log(response);
         })

--- a/src/stores/game.js
+++ b/src/stores/game.js
@@ -1,11 +1,10 @@
-import axios from "axios";
+import { setupAxiosInterceptors } from "@/plugins/setupAxios.js";
 import { defineStore } from "pinia"
-import { computed, ref } from "vue";
-
-const REST_API_URL = 'http://localhost:8080/api/game'
+import { ref } from "vue";
+import { useRouter } from "vue-router";
+import { useAuthStore } from "@/stores/auth";
 
 export const useGameStore = defineStore(`game`, () => {
-    // states
     const gameId = ref(-1);
     const gameType = ref('');
     const gameDifficultyLevel = ref('');
@@ -14,25 +13,19 @@ export const useGameStore = defineStore(`game`, () => {
     const gameIsAchieved = ref(false);
     const monthlyGame = ref([]);
     const games = ref([]);
-    const game = ref();
 
-    // getters
-    const typeString = computed(() => {
-        return gameType.value === 'PUSHUP' ? 'Push Up' : 'Squat';
-    });
+    const authStore = useAuthStore();
+    const router = useRouter();
+    const axiosInstance = setupAxiosInterceptors(authStore, router);
 
-    // actions
     const createGame = async (type, difficultyLevel, userId) => {
 
-        console.log("game.js - type: " + type);
-        console.log("game.js - difficultyLevel: " + difficultyLevel);
-        console.log("game.js - userId: " + userId);
         gameType.value = type;
         gameDifficultyLevel.value = difficultyLevel;
         gameUserId.value = userId;
 
         try {
-            const response = await axios.post(REST_API_URL, {
+            const response = await axiosInstance.post(`/game`, {
                 type: gameType.value,
                 difficultyLevel: gameDifficultyLevel.value,
                 userId: gameUserId.value
@@ -51,7 +44,7 @@ export const useGameStore = defineStore(`game`, () => {
         console.log(isAchieved);
 
         try {
-            const response = await axios.put(REST_API_URL, {
+            const response = await axiosInstance.put(`/game`, {
                 gameId: gameId.value,
                 isAchieved: gameIsAchieved.value
             });
@@ -63,7 +56,7 @@ export const useGameStore = defineStore(`game`, () => {
     }
 
     const fetchMonthlyGame = async (userId, year, month) => {
-        await axios.get(`${REST_API_URL}/${userId}`, {
+        await axiosInstance.get(`/game/${userId}`, {
             params: { year, month }
         })
         .then((response) => {
@@ -86,7 +79,7 @@ export const useGameStore = defineStore(`game`, () => {
     
 
     const fetchGameList = async (userId, date) => {
-        await axios.get(`${REST_API_URL}/list`, {
+        await axiosInstance.get(`/game/list`, {
             params: { userId, date }
         })
         .then((response) => {
@@ -108,7 +101,6 @@ export const useGameStore = defineStore(`game`, () => {
         gameIsAchieved,
         monthlyGame,
         games,
-        typeString,
         createGame,
         achieveGame,
         fetchMonthlyGame,

--- a/src/stores/todayChallenge.js
+++ b/src/stores/todayChallenge.js
@@ -1,8 +1,8 @@
-import axios from "axios";
+import { setupAxiosInterceptors } from "@/plugins/setupAxios.js";
 import { defineStore } from "pinia";
 import { ref } from 'vue';
-
-const REST_API_URL = `http://localhost:8080/api/today-challenge`;
+import { useRouter } from "vue-router";
+import { useAuthStore } from "@/stores/auth";
 
 export const useTodayChallengeStore = defineStore('todayChallenge', () => {
     const monthlyTodayChallenge = ref([]);
@@ -14,8 +14,12 @@ export const useTodayChallengeStore = defineStore('todayChallenge', () => {
     });
     const todayChallenges = ref([]);
 
+    const router = useRouter();
+    const authStore = useAuthStore();
+    const axiosInstance = setupAxiosInterceptors(authStore, router);
+
     const fetchTodayChallenge = async (challengeId, date) => {
-        await axios.get(REST_API_URL, {
+        await axiosInstance.get(`/today-challenge`, {
             params: { challengeId, date }
         })
         .then((response) => {
@@ -26,7 +30,7 @@ export const useTodayChallengeStore = defineStore('todayChallenge', () => {
         })
     }
     const fetchTodayChallengeList = async (userId, date) => {
-        await axios.get(`${REST_API_URL}/list`, {
+        await axiosInstance.get(`/today-challenge/list`, {
             params: { userId, date }
         })
         .then((response) => {
@@ -39,7 +43,7 @@ export const useTodayChallengeStore = defineStore('todayChallenge', () => {
         })
     }
     const updateTodayChallenge = async (todayChallenge) => {
-        await axios.put(REST_API_URL, todayChallenge)
+        await axiosInstance.put(`/today-challenge`, todayChallenge)
         .then((response) => {
             console.log(response);
         })
@@ -48,7 +52,7 @@ export const useTodayChallengeStore = defineStore('todayChallenge', () => {
         })
     }
     const fetchMonthlyTodayChallenge = async (userId, year, month) => {
-        await axios.get(`${REST_API_URL}/${userId}`, {
+        await axiosInstance.get(`/today-challenge/${userId}`, {
             params: { year, month }
         })
         .then((response) => {

--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -1,9 +1,9 @@
-import axios from "axios";
+import { setupAxiosInterceptors } from "@/plugins/setupAxios.js";
 import { defineStore } from "pinia";
 import { ref } from 'vue';
 import { getTierIcon, getNextTierIcon, getNextExp } from '@/utils/tierUtils';
-
-const REST_API_URL = `http://localhost:8080/api/user`;
+import { useRouter } from "vue-router";
+import { useAuthStore } from "@/stores/auth";
 
 export const useUserStore = defineStore('user', () => {
     const user = ref({
@@ -16,10 +16,16 @@ export const useUserStore = defineStore('user', () => {
         maxExp: 0,
         exp: 0,
     });
-    const userId = ref(1);
+    
+    const authStore = useAuthStore();
+    const router = useRouter();
+    const axiosInstance = setupAxiosInterceptors(authStore, router);
 
-    const fetchUserInfo = async (userId) => {
-        await axios.get(`${REST_API_URL}/${userId}`)
+    const userId = ref(0);
+
+    const fetchUserInfo = async (userIdParam) => {
+
+        await axiosInstance.get(`/user/${userIdParam}`)
         .then((response) => {
             user.value = response.data;
             user.value.curTierIcon = getTierIcon(user.value.tier);
@@ -27,18 +33,36 @@ export const useUserStore = defineStore('user', () => {
             user.value.maxExp = getNextExp(user.value.tier);
         })
         .catch((err) => {
-            console.log(err);
+            console.error("Error fetching user info:", err);
+            if (err.response && err.response.status === 403) {
+                console.error("다른 사용자의 데이터에 접근할 수 없습니다.");
+                const userIdForRoute = localStorage.getItem("userId");
+                router.push({ 
+                    name: "HomeView",
+                    params: { userId: userIdForRoute }
+                });
+            }
         })
     }
 
-    const updateUserInfo = (userId, user) => {
-        axios.put(`${REST_API_URL}/${userId}`, user)
+    const updateUserInfo = (userIdParam, user) => {
+        axiosInstance.put(`/user/${userIdParam}`, user)
         .then((response) => {
             console.log(response);
         })
         .catch((err) => {
-            console.log(err);
+            console.error("Error updating user info:", err);
+            if (err.response && err.response.status === 403) {
+                console.error("다른 사용자의 데이터를 수정할 수 없습니다.");
+                const userIdForRoute = localStorage.getItem("userId");
+                router.push({ name: "HomeView", params: { userId: userIdForRoute } });
+            }
         })
     }
-    return { user, userId, fetchUserInfo, updateUserInfo }
+    return {
+        user,
+        userId,
+        fetchUserInfo,
+        updateUserInfo
+    }
 })

--- a/src/views/GamePlayViewBomb.vue
+++ b/src/views/GamePlayViewBomb.vue
@@ -12,7 +12,7 @@
         <div v-else>
             <div id="ui-container">
                 <div class="game-info">
-                    <p>운동 종류: {{ gameStore.typeString }}</p>
+                    <p>운동 종류: {{ gameStore.gameType === 'PUSHUP' ? 'Push Up' : 'Squat' }}</p>
                     <p>난이도: {{ gameStore.gameDifficultyLevel }}</p>
                 </div>
                 <div id="counter-container">Count: <span id="counter">{{ counter }}</span></div>

--- a/src/views/GamePlayViewDuck.vue
+++ b/src/views/GamePlayViewDuck.vue
@@ -12,7 +12,7 @@
         <div v-else>
             <div id="ui-container">
                 <div class="game-info">
-                    <p>운동 종류: {{ gameStore.typeString }}</p>
+                    <p>운동 종류: {{ gameStore.gameType === 'PUSHUP' ? 'Push Up' : 'Squat' }}</p>
                     <p>난이도: {{ gameStore.gameDifficultyLevel }}</p>
                 </div>
                 <div id="counter-container">Count: <span id="counter">{{ counter }}</span></div>

--- a/src/views/GamePlayViewFlying.vue
+++ b/src/views/GamePlayViewFlying.vue
@@ -12,7 +12,7 @@
         <div v-else>
             <div id="ui-container">
                 <div class="game-info">
-                    <p>운동 종류: {{ gameStore.typeString }}</p>
+                    <p>운동 종류: {{ gameStore.gameType === 'PUSHUP' ? 'Push Up' : 'Squat' }}</p>
                     <p>난이도: {{ gameStore.gameDifficultyLevel }}</p>
                 </div>
                 <div id="counter-container">Count: <span id="counter">{{ counter }}</span></div>

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -13,15 +13,6 @@
             <h2 class="welcome-message">환영합니다!</h2>
             <p class="intro-text">HIM으로 힘을 길러보세요!</p>
 
-            <div class="social-buttons">
-                <button @click="socialLogin('Google')" class="social-button">
-                    <img src="https://img.icons8.com/color/48/000000/google-logo.png" alt="Google" class="icon">
-                    Google
-                </button>
-            </div>
-
-            <div class="divider-text">또는 이메일로 로그인해보세요!</div>
-
             <form @submit.prevent="login">
                 <div class="form-group">
                     <label class="form-label">이메일</label>
@@ -31,6 +22,7 @@
                     <label class="form-label">비밀번호</label>
                     <input type="password" v-model="password" class="input-field" placeholder="Password">
                 </div>
+                <div v-if="loginError" class="error-message">{{ loginError }}</div>
                 <div class="form-options">
                     <label class="checkbox-container">
                         <input type="checkbox" v-model="rememberMe" class="form-checkbox">
@@ -56,23 +48,35 @@
 
 
 <script setup>
+import { useAuthStore } from "@/stores/auth";
+import { useRouter } from "vue-router";
 import { ref, onMounted } from 'vue'
-const email = ref('');
-const password = ref('');
-const rememberMe = ref(false);
 const floatingIcons = ref([]);
 const icons = ["💪", "❤️", "🏋️‍♂️", "🔥", "💚", "⏱️", "👟", "🏆", "💦", "🤸‍♀️",
     "🚴", "🏃", "🥇", "🏅", "🧘", "🩺", "🥗", "🍎", "🥤", "🚶"];
 
-const socialLogin = (platform) => {
-    alert(`${platform} 로그인 기능은 아직 구현되지 않았습니다.`);
-};
+const email = ref('');
+const password = ref('');
+const rememberMe = ref(false);
+const loginError = ref("");
 
-const login = () => {
-    if (email.value && password.value) {
-        alert(`환영합니다, ${email.value}! 로그인되었습니다.`);
+const authStore = useAuthStore();
+const router = useRouter();
+
+const login = async () => {
+    if (!email.value || !password.value) {
+        loginError.value = "이메일과 비밀번호를 입력하세요.";
+        return;
+    }
+
+    const success = await authStore.login(email.value, password.value);
+    if (success) {
+        router.push({
+            name: "HomeView",
+            params: { userId: authStore.userInfo.userId },
+        });
     } else {
-        alert("이메일과 비밀번호를 입력하세요.");
+        loginError.value = "로그인에 실패했습니다. 이메일 또는 비밀번호를 확인하세요.";
     }
 };
 
@@ -148,42 +152,10 @@ onMounted(() => {
     width: 30%;
 }
 
-.social-buttons {
-    display: flex;
-    justify-content: center;
-    gap: 1rem;
-    margin-bottom: 1.5rem;
-}
-
-.social-button {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    padding: 0.5rem;
-    border: 1px solid #d1d5db;
-    border-radius: 0.5rem;
-    font-size: 1rem;
-    transition: background-color 0.3s;
-    color: #718096;
-    font-family: 'HakgyoansimDunggeunmisoTTF-B';
-    cursor: pointer;
-}
-
-.social-button:hover {
-    background-color: #d5d5df;
-}
-
 .icon {
     height: 1.25rem;
     width: 1.25rem;
     margin-right: 0.5rem;
-}
-
-.divider-text {
-    text-align: center;
-    color: #a0aec0;
-    margin-bottom: 1rem;
 }
 
 .form-group {
@@ -293,5 +265,12 @@ onMounted(() => {
     100% {
         transform: translateY(-30px);
     }
+}
+
+.error-message {
+    color: #d32f2f;
+    font-size: 0.9rem;
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
 }
 </style>

--- a/src/views/SignUpView.vue
+++ b/src/views/SignUpView.vue
@@ -13,36 +13,69 @@
             <h2 class="welcome-message">환영합니다!</h2>
             <p class="intro-text">HIM으로 힘을 길러보세요!</p>
 
-            <div class="divider-text">소셜 로그인도 가능합니다!</div>
+            <form @submit.prevent="validateAndSubmit">
+                <div class="form-group hint-group">
+                    <label class="form-label">사용할 닉네임을 입력해주세요.</label>
+                    <small class="hint-text">닉네임은 한글/영문 포함 최대 10글자까지 가능합니다.</small>
+                    <input type="text" v-model="nickname" class="input-field" @input="limitNicknameLength"
+                        placeholder="예) 나는운동강아지" required>
+                </div>
+                <div class="form-group hint-group">
+                    <label class="form-label">이메일을 입력해주세요.</label>
+                    <small v-if="verificationMessage" :class="verificationSuccess ? 'hint-success' : 'hint-error'">
+                        {{ verificationMessage }}
+                    </small>
+                    <div class="email-input-wrapper">
+                        <input type="email" v-model="email" class="input-field" placeholder="예) him@google.com"
+                            @input="validateEmail" required>
+                        <button type="button" class="verify-button" @click="handleSendVerificationCode"
+                            :disabled="!isEmailValid">
+                            인증코드 요청
+                        </button>
+                    </div>
+                </div>
+                <div class="form-group hint-group">
+                    <label class="form-label">인증 코드를 입력해주세요.</label>
+                    <small v-if="verificationCheckMessage"
+                        :class="verificationCheckSuccess ? 'hint-success' : 'hint-error'">
+                        {{ verificationCheckMessage }}
+                    </small>
+                    <div class="email-input-wrapper">
+                        <input type="text" v-model="authCode" class="input-field" placeholder="이메일 코드" required>
+                        <button type="button" class="verify-button" @click="handleVerifyCode" :disabled="!authCode">
+                            인증하기
+                        </button>
+                    </div>
+                </div>
+                <div class="form-group hint-group">
+                    <label class="form-label">비밀번호를 입력해주세요.</label>
+                    <small class="alarm-text" v-if="passwordMessage"> 비밀번호는 8자 이상의 숫자, 특수 문자(!@#$%^&*), 영문자를
+                        포함해주세요.</small>
+                    <input type="password" v-model="password" class="input-field" placeholder="비밀번호"
+                        @input="validatePassword" required>
+                </div>
+                <div class="form-group hint-group">
+                    <label class="form-label">비밀번호를 다시 입력해주세요.</label>
+                    <span class="alarm-text" v-if="passwordMatchMessage">{{ passwordMatchMessage }}</span>
+                    <input type="password" v-model="passwordRetype" class="input-field" placeholder="비밀번호 재입력"
+                        @input="checkPasswordMatch" required>
+                </div>
 
-            <div class="social-buttons">
-                <button @click="socialLogin('Google')" class="social-button">
-                    <img src="https://img.icons8.com/color/48/000000/google-logo.png" alt="Google" class="icon">
-                    Google
-                </button>
-            </div>
-
-            <form @submit.prevent="signUp">
-                <div class="form-group">
-                    <label class="form-label">이름</label>
-                    <input type="name" v-model="password" class="input-field" placeholder="Password">
-                </div>
-                <div class="form-group">
-                    <label class="form-label">이메일</label>
-                    <input type="email" v-model="email" class="input-field" placeholder="him@google.com">
-                </div>
-                <div class="form-group">
-                    <label class="form-label">비밀번호</label>
-                    <input type="password" v-model="password" class="input-field" placeholder="Password">
-                </div>
-                <div class="form-group">
-                    <label class="form-label">비밀번호 재입력</label>
-                    <input type="passwordRetype" v-model="password" class="input-field" placeholder="Password">
-                </div>
-                
-                <button type="submit" class="signup-button">회원가입하기</button>
+                <button type="submit" class="signup-button" :disabled="!isFormValid">회원가입하기</button>
             </form>
         </div>
+
+        <div v-if="showPopup" class="popup-overlay">
+            <div class="popup-content">
+                <h3 style="font-size: 2rem;">회원가입에 성공했습니다!</h3>
+                <div style="color: brown; margin-bottom: 10px;">꾸준함 속에 달콤한 열매가 있습니다.</div>
+                <div style="color: brown; margin-bottom: 10px;">HIM은 여러분의 꾸준함을 보장합니다.</div>
+                <div style="color: brown;">자, 이제 달콤한 열매를 얻을 준비가 되셨나요?</div>
+                <button @click="goToLogin" class="popup-button">로그인하기</button>
+            </div>
+        </div>
+
+        <Modal :visible="showModal" :title="modalTitle" :message="modalMessage" @close="showModal = false" />
 
         <div v-for="(icon, index) in floatingIcons" :key="index" class="floating-icon"
             :style="{ top: icon.top, left: icon.left, animationDuration: icon.speed }">
@@ -52,23 +85,144 @@
 </template>
 
 <script setup>
+import Modal from "@/components/Modal.vue";
+import { useAuthStore } from '@/stores/auth.js';
 import { ref, onMounted } from 'vue';
+import { useRouter } from 'vue-router';
 
-const name = ref('');
+const authStore = useAuthStore();
+const router = useRouter();
+
+const nickname = ref('');
 const email = ref('');
+const authCode = ref('');
 const password = ref('');
 const passwordRetype = ref('');
-const rememberMe = ref(false);
-const floatingIcons = ref([]);
-const icons = ["💪", "❤️", "🏋️‍♂️", "🔥", "💚", "⏱️", "👟", "🏆", "💦", "🤸‍♀️", "🚴", "🏃", "🥇", "🏅", "🧘", "🩺", "🥗", "🍎", "🥤", "🚶"];
 
-const signUp = () => {
-    if (email.value && password.value) {
-        alert(`환영합니다, ${email.value}! 로그인되었습니다.`);
+const passwordMessage = ref('');
+const passwordMatchMessage = ref('');
+
+const isFormValid = ref(false);
+const isEmailValid = ref(false);
+const showPopup = ref(false);
+
+const showModal = ref(false);
+const modalTitle = ref('');
+const modalMessage = ref('');
+
+const currentLength = ref(0);
+
+const verificationMessage = ref("");
+const verificationSuccess = ref(false);
+
+const verificationCheckMessage = ref("");
+const verificationCheckSuccess = ref(false);
+
+const validatePassword = () => {
+    const value = password.value;
+    const errors = [];
+
+    if (!/[a-zA-Z]/.test(value)) errors.push('영문자');
+    if (!/[0-9]/.test(value)) errors.push('숫자');
+    if (!/[!@#$%^&*]/.test(value)) errors.push('특수 문자(!@#$%^&*)');
+    if (value.length < 8) errors.push('8자 이상');
+
+    if (errors.length > 0) {
+        passwordMessage.value = `비밀번호는 ${errors.join(', ')}가 포함되어야 합니다.`;
     } else {
-        alert("이메일과 비밀번호를 입력하세요.");
+        passwordMessage.value = '';
+    }
+
+    updateFormValidity();
+};
+
+const checkPasswordMatch = () => {
+    if (password.value !== passwordRetype.value) {
+        passwordMatchMessage.value = '비밀번호가 일치하지 않습니다.';
+    } else {
+        passwordMatchMessage.value = '';
+    }
+
+    updateFormValidity();
+};
+
+const validateEmail = () => {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    isEmailValid.value = emailRegex.test(email.value.trim());
+};
+
+const updateFormValidity = () => {
+    isFormValid.value =
+        nickname.value.trim() !== '' &&
+        email.value.trim() !== '' &&
+        passwordMessage.value === '' &&
+        passwordMatchMessage.value === '' &&
+        passwordRetype.value.trim() !== '' &&
+        verificationCheckSuccess.value;
+};
+
+const validateAndSubmit = async () => {
+    const userData = {
+        nickname: nickname.value,
+        email: email.value,
+        password: password.value,
+    };
+
+    await authStore.signUp(userData);
+
+    if (authStore.signupStatus.success) {
+        showPopup.value = true;
+    } else {
+        modalTitle.value =
+            authStore.signupStatus.errorType === "nickname"
+                ? "닉네임 중복"
+                : authStore.signupStatus.errorType === "email"
+                    ? "이메일 중복"
+                    : "오류";
+        modalMessage.value = authStore.signupStatus.message;
+        showModal.value = true;
     }
 };
+
+const goToLogin = () => {
+    showPopup.value = false;
+    router.push('/login-view');
+};
+
+const handleSendVerificationCode = async () => {
+    await authStore.sendVerificationCode(email.value);
+    const status = authStore.verificationStatus;
+    verificationSuccess.value = status.success;
+    verificationMessage.value = status.message;
+};
+
+const handleVerifyCode = async () => {
+    await authStore.verifyCode(email.value, authCode.value);
+    const status = authStore.verificationStatus;
+    verificationCheckSuccess.value = status.success;
+    verificationCheckMessage.value = status.message;
+    updateFormValidity();
+};
+
+const limitNicknameLength = () => {
+    const nicknameValue = nickname.value;
+
+    const totalLength = Array.from(nicknameValue).reduce((acc, char) => {
+        const isKorean = /[ㄱ-ㅎㅏ-ㅣ가-힣]/.test(char);
+        return acc + (isKorean ? 1 : 1);
+    }, 0);
+
+    if (totalLength > 10) {
+        nickname.value = Array.from(nicknameValue)
+            .slice(0, 10)
+            .join('');
+    }
+
+    currentLength.value = Math.min(totalLength, 10);
+};
+
+const floatingIcons = ref([]);
+const icons = ["💪", "❤️", "🏋️‍♂️", "🔥", "💚", "⏱️", "👟", "🏆", "💦", "🤸‍♀️", "🚴", "🏃", "🥇", "🏅", "🧘", "🩺", "🥗", "🍎", "🥤", "🚶"];
 
 const createFloatingIcons = () => {
     for (let i = 0; i < 60; i++) {
@@ -131,6 +285,18 @@ onMounted(() => {
     margin-bottom: 1.5rem;
 }
 
+.alarm-text {
+    display: block;
+    font-size: 0.8rem;
+    color: #e92a2a;
+}
+
+.hint-text {
+    display: block;
+    font-size: 0.8rem;
+    color: #718096;
+}
+
 .logo-container {
     display: flex;
     justify-content: center;
@@ -149,7 +315,7 @@ onMounted(() => {
 .form-label {
     display: block;
     color: #4a5568;
-    font-size: 1.3rem;
+    font-size: 1.1rem;
     margin-bottom: 0.5rem;
 }
 
@@ -200,40 +366,12 @@ onMounted(() => {
     cursor: pointer;
 }
 
-.signup-button:hover {
-    background-color: #f06292;
-}
-
-.social-buttons {
-    display: flex;
-    justify-content: center;
-    gap: 1rem;
-    margin-bottom: 1.5rem;
-}
-
-.social-button {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    padding: 0.5rem;
-    border: 1px solid #d1d5db;
-    border-radius: 0.5rem;
-    font-size: 1rem;
-    transition: background-color 0.3s;
-    color: #718096;
-    font-family: 'HakgyoansimDunggeunmisoTTF-B';
-    cursor: pointer;
-}
-
-.social-button:hover {
-    background-color: #d5d5df;
-}
-
-.divider-text {
-    text-align: center;
-    color: #a0aec0;
-    margin-bottom: 1rem;
+.signup-button:disabled {
+    background-color: #a5d6a7;
+    border: 2px solid #a5d6a7;
+    color: #ffffff;
+    opacity: 0.6;
+    cursor: not-allowed;
 }
 
 .icon {
@@ -258,5 +396,107 @@ onMounted(() => {
     100% {
         transform: translateY(-30px);
     }
+}
+
+.popup-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.popup-content {
+    background: #fff;
+    padding: 20px;
+    border-radius: 10px;
+    text-align: center;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+    font-size: 1.3rem;
+}
+
+.popup-button {
+    background-color: #4CAF50;
+    color: white;
+    padding: 15px 35px;
+    border: none;
+    border-radius: 5px;
+    font-size: 1.5rem;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+    margin-top: 30px;
+    font-family: 'HakgyoansimDunggeunmisoTTF-B';
+}
+
+.popup-button:hover {
+    background-color: #45a049;
+}
+
+.hint-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+/* .hint-text {
+    display: block;
+    font-size: 0.8rem;
+    color: #718096;
+} */
+
+.hint-success {
+    display: block;
+    color: #2e7d32;
+    font-size: 0.8rem;
+    /* margin-top: 0.3rem; */
+}
+
+.hint-error {
+    display: block;
+    color: #d32f2f;
+    font-size: 0.8rem;
+    /* margin-top: 0.3rem; */
+}
+
+.email-input-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    /* 입력 필드와 버튼 간격 */
+}
+
+.input-field {
+    flex: 1;
+    /* 입력 필드가 버튼보다 넓게 */
+    padding: 0.5rem;
+    font-size: 1rem;
+}
+
+.verify-button {
+    padding: 0.5rem 1rem;
+    background-color: #4CAF50;
+    color: white;
+    border: none;
+    border-radius: 5px;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+    font-family: 'HakgyoansimDunggeunmisoTTF-B';
+}
+
+.verify-button:hover {
+    background-color: #45a049;
+}
+
+.verify-button:disabled {
+    background-color: #a5d6a7;
+    cursor: not-allowed;
+    color: white;
+    opacity: 0.6;
 }
 </style>


### PR DESCRIPTION
## 연관된 이슈

> #46 

## 작업 내용
- 회원가입
> 백엔드에서 구현한 Auth 기능에 대한 api을 연동하였습니다.
> 회원가입, 로그인, 로그아웃 기능을 구현하였습니다.
> 이메일 인증 기능을 구현하였습니다.
> 닉네임의 길이를 제한하고, 비밀번호 제한 사항을 적용하였습니다.
> 비밀번호 일치/불일치를 구현하였습니다.

- 로그인
> 액세스 토큰을 백엔드에서 받아와 로컬 스토리지에 저장하는 기능을 구현하였습니다.
> 프론트엔드의 interceptor 기능을 활용하여 액세스 토큰이 만료되었을 때, 백엔드에서 새로 발급한 액세스 토큰을 받을 수 있게 하였습니다.

- 로그아웃
> 로그아웃을 백엔드 요청하고, 스토어에 가지고 있는 로그인 관련 정보를 초기화합니다.
> 시작화면으로 라우트합니다.

### 스크린샷 (선택)
### 회원가입 화면
![스크린샷 2024-11-22 171923](https://github.com/user-attachments/assets/a16689f5-52da-4129-a8be-62b755e649dd)

## 리뷰 요구사항 (선택)

> 현재 백엔드의 액세스 토큰과 리프레쉬 토큰이 불안정하여 추가적인 보완과 디버깅이 필요할 것 같습니다.