### PR TITLE
챌린지 박스 버그 해결

### DIFF
--- a/src/stores/challenge.js
+++ b/src/stores/challenge.js
@@ -7,6 +7,7 @@ import { useAuthStore } from "@/stores/auth";
 export const useChallengeStore = defineStore('challenge', () => {
     const challenges = ref([]);
     const currentChallenge = ref(null);
+    const challengeTitle = ref("");
     
     const authStore = useAuthStore();
     const router = useRouter();
@@ -43,7 +44,6 @@ export const useChallengeStore = defineStore('challenge', () => {
         axiosInstance.post(`/challenge`, challenge)
         .then((response) => {
             console.log(response);
-            challenges.value.push(response.data);
         })
         .catch((err) => {
             console.log(err);

--- a/src/views/ChallengeSelectView.vue
+++ b/src/views/ChallengeSelectView.vue
@@ -28,7 +28,7 @@
 
                     <div v-if="isEditing && editIndex === index" class="edit-form open">
                         <span @click="isEditing = false" class="icon-button close-button">❌</span>
-                        <form @submit.prevent="saveChallenge">
+                        <form @submit.prevent="updateChallenge">
                             <div class="challenge-info">
                                 <label style="font-size: 1.2rem;">🏆 챌린지 이름</label>
                                 <div placeholder="예: '30일 푸쉬업 챌린지'" disabled>{{ editChallenge.title }}</div>
@@ -83,7 +83,7 @@
                 </div>
 
                 <div v-if="isCreating" class="challenge-box new-challenge-form open">
-                    <form @submit.prevent="saveChallenge">
+                    <form @submit.prevent="createChallenge">
                         <span @click="isCreating = false" class="icon-button close-button2">❌</span>
 
                         <div class="challenge-info">
@@ -167,7 +167,7 @@
 </template>
 
 <script setup>
-import { ref, reactive, onMounted, computed } from 'vue';
+import { ref, reactive, onMounted } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useRouter, useRoute } from 'vue-router';
 import { useChallengeStore } from '@/stores/challenge';
@@ -272,9 +272,10 @@ const resetForm = () => {
     newChallenge.endDt = "";
     newChallenge.goalCnt = null;
     isCreating.value = false;
+    editIndex.value = null;
 };
 
-const saveChallenge = () => {
+const createChallenge = () => {
     if (newChallenge.endDt && newChallenge.goalCnt) {
         challenges.value.push({
             title: newChallenge.title,
@@ -282,12 +283,19 @@ const saveChallenge = () => {
             icon: newChallenge.type === "PUSHUP" ? "💪" : "🏋️‍♂️",
             endDt: newChallenge.endDt,
             goalCnt: newChallenge.goalCnt,
-            progress: 0
+            progress: 0,
         });
 
         challengeStore.addChallenge(newChallenge);
         resetForm();
-    } else if (editChallenge.endDt && editChallenge.goalCnt) {
+    } else {
+        alert("날짜와 목표를 입력해주세요.");
+    }
+};
+
+
+const updateChallenge = () => {
+    if (editChallenge.endDt && editChallenge.goalCnt) {
         challenges.value[editIndex.value] = {
             id: editChallenge.id,
             title: editChallenge.title,
@@ -297,10 +305,12 @@ const saveChallenge = () => {
             endDt: editChallenge.endDt,
             goalCnt: editChallenge.goalCnt,
             userId: editChallenge.userId,
-            progress: challenges.value[editIndex.value].progress
+            progress: challenges.value[editIndex.value].progress,
         };
+
         challengeStore.updateChallenge(editChallenge.id, editChallenge);
         isEditing.value = false;
+        editIndex.value = null;
     } else {
         alert("날짜와 목표를 입력해주세요.");
     }
@@ -323,7 +333,7 @@ const addFloatingIcons = () => {
 
 onMounted(async () => {
     try {
-        await challengeStore.fetchChallenges(1, "ONGOING");
+        challengeStore.fetchChallenges(1, "ONGOING");
     } catch (error) {
         console.error(error);
     }


### PR DESCRIPTION
## 연관된 이슈

> resolve #60

## 작업 내용

> 챌린지 선택 화면에서 챌린지 생성 시, 챌린지 박스가 2개가 생성되는 버그를 해결하였습니다.
> challnege.js 스토어에서 addChallnege 메서드는 axios을 통해 백엔드와 연결하여 db을 수정하는 역할을 맡는데, 이 부분에서 응답 데이터를 다시 challenges 배열에 담습니다. challenges는 challnegeSelectView에서와 challenge.js에서 중복으로 담기기 때문에 2개의 박스가 발생하였고, challenge.js의 응답 데이터를 challenges 배열에 담는 부분을 삭제하니 해결되었습니다.
> 추가적으로 challnegeSelectView에서 기존의 saveChallenge 메서드는 챌린지를 수정하고 생성하는 기능을 전부 가지고 있었는데, 가독성이 좋지 않아 updateChallenge와 createChallenge에 대한 메서드로 분리하여 가독성을 높였습니다.

### 스크린샷 (선택)

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?