### PR TITLE
챌린지 조회 시, userId 값 수정 

### DIFF
--- a/src/views/ChallengeSelectView.vue
+++ b/src/views/ChallengeSelectView.vue
@@ -323,7 +323,7 @@ const addFloatingIcons = () => {
 
 onMounted(async () => {
     try {
-        await challengeStore.fetchChallenges(1, "ONGOING");
+        await challengeStore.fetchChallenges(userId, "ONGOING");
     } catch (error) {
         console.error(error);
     }


### PR DESCRIPTION
## 연관된 이슈

> 

## 작업 내용

> challengeSelectView 파트에서 챌린지 조회 시 userId가 하드코딩되어있던 부분을 수정하여 userId 별 챌린지들을 반환할 수 있도록 수정하였습니다.