### PR TITLE
챌린지 카운트 버그 해결 및 게임 난이도 재조정

### DIFF
--- a/src/components/FailScreen.vue
+++ b/src/components/FailScreen.vue
@@ -34,7 +34,7 @@ const newGame = () => {
 
 const retryGame = () => {
   router.push({
-    name: gameTheme,
+    name: "GamePlayView",
     params: {
       id: gameId,
       type: gameType.value,

--- a/src/components/SuccessScreen.vue
+++ b/src/components/SuccessScreen.vue
@@ -12,8 +12,8 @@
         <div id="success-overlay">
             <div id="success-text">SUCCESS!</div>
             <div class="game-info">
-                <p>운동 종류: {{ gameStore.typeString }}</p>
-                <div>난이도: {{ gameStore.gameDifficultyLevel }}</div>
+                <p>운동 종류: {{ gameType === 'PUSHUP' ? 'Push Up' : 'Squat' }}</p>
+                <div>난이도: {{ gameDifficultyLevel }}</div>
             </div>
             <div id="celebration-message">축하합니다! 목표를 달성했습니다!</div>
 
@@ -43,16 +43,17 @@
 <script setup>
 import { ref, onMounted, watch, computed } from 'vue';
 import { useRouter, useRoute } from 'vue-router';
-import { useGameStore } from '@/stores/game';
 import { useUserStore } from '@/stores/user';
 import { storeToRefs } from 'pinia';
-
-const gameStore = useGameStore();
 const userStore = useUserStore();
 const router = useRouter();
 const route = useRoute();
 const { user } = storeToRefs(userStore);
 
+const gameType = ref('');
+gameType.value = route.params.type;
+const gameDifficultyLevel = ref('');
+gameDifficultyLevel.value = route.params.difficultyLevel;
 const gameExp = route.params.expPoints;
 const userId = route.params.userId;
 const prevTier = route.params.prevTier;

--- a/src/plugins/setupAxios.js
+++ b/src/plugins/setupAxios.js
@@ -9,7 +9,6 @@ export const setupAxiosInterceptors = (authStore, router) => {
     instance.interceptors.request.use(
         (config) => {
             const token = localStorage.getItem("accessToken");
-            console.log(token);
             if (token) {
                 config.headers["Authorization"] = `Bearer ${token}`;
             } else {
@@ -41,7 +40,5 @@ export const setupAxiosInterceptors = (authStore, router) => {
         }
     );
     
-
-
     return instance;
 };

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -58,7 +58,7 @@ const routes = [
     component: FailScreen,
   },
   {
-    path: '/success-screen/:userId/:prevTier/:expPoints',
+    path: '/success-screen/:id/:type/:difficultyLevel/:userId/:prevTier/:expPoints',
     name: 'SuccessScreen',
     component: SuccessScreen,
   },

--- a/src/views/ChallengePlayView.vue
+++ b/src/views/ChallengePlayView.vue
@@ -23,15 +23,13 @@
                     <p>성취 개수: {{ challengeStore.currentChallenge.achievedCnt }}</p>
                     <p>목표 개수: {{ challengeStore.currentChallenge.goalCnt }}</p>
                 </div>
-                <div v-if="showCounter" :key="counter" id="counter-container" class="animate-counter">
+                <div :key="counter" id="counter-container" class="animate-counter">
                     <span id="counter">{{ counter }}</span>
                 </div>
             </div>
 
             <button @click="openSaveModal" class="save-button">저장하기</button>
         </div>
-
-        <!-- <button v-if="countdown === 0" @click="openSaveModal" class="save-button">저장하기</button> -->
 
         <div v-if="isModalOpen" class="modal-overlay">
             <div class="modal">
@@ -66,7 +64,6 @@ const challengeId = route.params.challengeId;
 const { currentTodayChallenge } = storeToRefs(todayChallengeStore);
 const { currentChallenge } = storeToRefs(challengeStore);
 const counter = ref(0);
-const showCounter = ref(false);
 const countdown = ref(4);
 const isModalOpen = ref(false);
 let updateInterval = null;
@@ -163,10 +160,6 @@ function startGame() {
             const newCounterValue = await getCounter();
             if (newCounterValue !== counter.value) {
                 counter.value = newCounterValue;
-                showCounter.value = true;
-                setTimeout(() => {
-                    showCounter.value = false;
-                }, 1500);
             }
         } catch (error) {
             console.error("카운터 업데이트 중 오류 발생:", error);

--- a/src/views/GamePlayView.vue
+++ b/src/views/GamePlayView.vue
@@ -173,9 +173,9 @@ const startPixiAndTM = async () => {
             successLimit: 150,
             frameInterval: 1,
             difficulties: {
-                EASY: { countMoveSpeed: 110, penaltyMoveSpeed: 2 },
-                MEDIUM: { countMoveSpeed: 90, penaltyMoveSpeed: 3 },
-                HARD: { countMoveSpeed: 70, penaltyMoveSpeed: 4 },
+                EASY: { countMoveSpeed: 200, penaltyMoveSpeed: 2 },
+                MEDIUM: { countMoveSpeed: 200, penaltyMoveSpeed: 3 },
+                HARD: { countMoveSpeed: 200, penaltyMoveSpeed: 4 },
             },
         },
         GamePlayViewBomb: {
@@ -187,9 +187,9 @@ const startPixiAndTM = async () => {
             successLimit: 100,
             frameInterval: 3,
             difficulties: {
-                EASY: { countMoveSpeed: 110, penaltyMoveSpeed: 2 },
-                MEDIUM: { countMoveSpeed: 90, penaltyMoveSpeed: 3 },
-                HARD: { countMoveSpeed: 70, penaltyMoveSpeed: 4 },
+                EASY: { countMoveSpeed: 200, penaltyMoveSpeed: 2 },
+                MEDIUM: { countMoveSpeed: 200, penaltyMoveSpeed: 3 },
+                HARD: { countMoveSpeed: 200, penaltyMoveSpeed: 4 },
             },
         },
         GamePlayViewFlying: {
@@ -201,9 +201,9 @@ const startPixiAndTM = async () => {
             successLimit: 0,
             frameInterval: 3,
             difficulties: {
-                EASY: { countMoveSpeed: 90, penaltyMoveSpeed: 2 },
-                MEDIUM: { countMoveSpeed: 70, penaltyMoveSpeed: 3 },
-                HARD: { countMoveSpeed: 50, penaltyMoveSpeed: 4 },
+                EASY: { countMoveSpeed: 150, penaltyMoveSpeed: 2 },
+                MEDIUM: { countMoveSpeed: 150, penaltyMoveSpeed: 3 },
+                HARD: { countMoveSpeed: 150, penaltyMoveSpeed: 4 },
             },
         },
     };
@@ -330,6 +330,9 @@ const startPixiAndTM = async () => {
         router.push({
             name: 'SuccessScreen',
             params: {
+                id: gameId,
+                type: gameType.value,
+                difficultyLevel: gameDifficultyLevel.value,
                 userId: userId,
                 prevTier: prevTier.value,
                 expPoints: gameStore.gameExpPoints,

--- a/src/views/GameSelectView.vue
+++ b/src/views/GameSelectView.vue
@@ -81,20 +81,18 @@
                     </div>
                 </div>
 
-                <div v-for="(difficulties, exercise) in groupedByExercise" :key="exercise" class="exp-card">
+                <div v-for="exercise in Object.keys(groupedByExercise).reverse()" :key="exercise" class="exp-card">
                     <h5 class="info-section">
-                        {{ exercise === 'PUSHUP' ? 'Push Up' : 'Squat'}}
+                        {{ exercise === 'PUSHUP' ? 'Push Up' : 'Squat' }}
                     </h5>
                     <ul class="list-unstyled">
-                        <li 
-                        v-for="(status, difficulty) in difficulties" 
-                        :key="difficulty" 
-                        :class="['list', status === 'completed' ? 'completed' : 'pending']"
-                        >
-                        {{ difficulty }}: {{ expByDifficulty[difficulty] }} exp
+                        <li v-for="(status, difficulty) in groupedByExercise[exercise]" :key="difficulty"
+                            :class="['list', status === 'completed' ? 'completed' : 'pending']">
+                            {{ difficulty }}: {{ expByDifficulty[difficulty] }} exp
                         </li>
                     </ul>
                 </div>
+
             </div>
         </div>
 


### PR DESCRIPTION
## 연관된 이슈

> resolve #71 #72

## 작업 내용

> 챌린지 플레이 화면에서 카운트가 나오지 않는 현상을 해결하였습니다.
> 게임 난이도가 높다고 판단하여 이를 하향 조정하였습니다.
> 게임 목록 순서 변경, 성공화면을 기존 기능과의 동기화, 실패화면의 라우터 수정 등 이전 테스트에서 미처 고치지 못한 오류들을 수정하였습니다. 

### 스크린샷 (선택)

## 리뷰 요구사항 (선택)

챌린지를 테스트하는 도중 다음과 같은 오류가 발생하였습니다.

1. 챌린지 생성 후에도 챌린지 선택 화면과 홈 화면의 챌린지 목록이 업데이트 안됨
2. 챌린지 이전에 운동한 카운트(성취 갯수)가 업데이트 안됨
 -> 챌린지 플레이 화면에 업데이트 안됨
 -> 챌린지 플레이 시, 해당 값부터 시작 안됨
3. 챌린지 달성 시 경험치 업데이트 안됨
4. 챌린지 생성 직후, 해당 챌린지 시작이 안됨
-> 페이지를 새로고침 했을 때에만 됨

챌린지 파트에서 제가 수정한 부분은 티쳐블 머신과의 연동 파트입니다. 챌린지의 타입을 파라미터로 전달하는 과정만 수정되었습니다. 특정 챌린지를 생성 직후, 이 챌린지에 대한 정보가 스토어에 업데이트되지 않아 해당 챌린지에 대한 정보를 가져오지 못하는 것으로 생각합니다. 이 버그들을 수정할 필요가 있습니다.