### PR TITLE
챌린지 로직 관련 에러 해결

### DIFF
--- a/src/components/ChallengeSuccessScreen.vue
+++ b/src/components/ChallengeSuccessScreen.vue
@@ -47,7 +47,6 @@ import { useChallengeStore } from '@/stores/challenge';
 import { useUserStore } from '@/stores/user';
 import { storeToRefs } from 'pinia';
 
-const todayChallengeStore = useTodayChallengeStore();
 const challengeStore = useChallengeStore();
 const userStore = useUserStore();
 const router = useRouter();

--- a/src/stores/challenge.js
+++ b/src/stores/challenge.js
@@ -13,8 +13,8 @@ export const useChallengeStore = defineStore('challenge', () => {
     const router = useRouter();
     const axiosInstance = setupAxiosInterceptors(authStore, router);
 
-    const fetchCurrentChallenge = (challengeId) => {
-        axiosInstance.get(`/challenge/${challengeId}`)
+    const fetchCurrentChallenge = async (challengeId) => {
+        await axiosInstance.get(`/challenge/${challengeId}`)
         .then((response) => {
             currentChallenge.value = response.data;
             challengeTitle.value = currentChallenge.value.title;

--- a/src/views/ChallengePlayView.vue
+++ b/src/views/ChallengePlayView.vue
@@ -71,9 +71,8 @@ const userId = route.params.userId;
 const isLoading = ref(true);
 
 onMounted(async () => {
-    challengeStore.fetchCurrentChallenge(challengeId);
-
-    await tmInit(challengeStore.currentChallenge.type, "CHALLENGE").then(() => {
+    await challengeStore.fetchCurrentChallenge(challengeId);
+    await tmInit(currentChallenge.value.type, "CHALLENGE").then(() => {
         console.log("Teachable Machine 초기화 완료");
     }).catch((error) => {
         console.error("Teachable Machine 초기화 중 오류 발생:", error);

--- a/src/views/ChallengeSelectView.vue
+++ b/src/views/ChallengeSelectView.vue
@@ -153,7 +153,7 @@
                                 현재 생성된 챌린지가 없습니다.
                             </li>
                             <li v-for="(challenge, index) in processedChallenges" :key="index"
-                                :class="['list', challenge.status === 'completed' ? 'completed' : 'pending']">
+                                :class="['list', challenge.achieved === true ? 'completed' : 'pending']">
                                 {{ challenge.title }}: 5 exp
                             </li>
                         </ul>

--- a/src/views/ChallengeSelectView.vue
+++ b/src/views/ChallengeSelectView.vue
@@ -123,7 +123,7 @@
                 </div>
             </div>
 
-            <button @click="startChallenge(selectedChallenge.id)" class="custom-button" :disabled="!selectedChallenge"
+            <button @click="startChallenge()" class="custom-button" :disabled="!selectedChallenge"
                 :style="{ animation: selectedChallenge ? '' : 'jittery 4s infinite' }">
                 <span>시작하기</span>
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="4" width="130"
@@ -197,6 +197,7 @@ const selectedChallenge = ref(null);
 const isDeleteModalOpen = ref(false);
 const deleteIndex = ref(null);
 const showInfo = ref(false);
+const selectedChallengeId = ref(0);
 
 const { processedChallenges } = useProcessedChallenges(todayChallenges, challenges);
 
@@ -207,6 +208,7 @@ const calculateProgress = (achievedCnt, startDt, endDt) => {
 
 const selectChallenge = (index) => {
     selectedChallenge.value = challenges.value[index];
+    selectedChallengeId.value = selectedChallenge.value.id;
 };
 
 const deleteChallenge = (index) => {
@@ -234,12 +236,12 @@ function closeDeleteModal() {
     isDeleteModalOpen.value = false;
 }
 
-const startChallenge = (id) => {
+const startChallenge = () => {
     if (selectedChallenge.value) {
         router.push({
             name: 'ChallengePlayView',
             params: {
-                challengeId: id,
+                challengeId: selectedChallengeId.value,
                 userId: userId
             }
         });


### PR DESCRIPTION
## 연관된 이슈

> 

## 작업 내용

> 챌린지 로직에서 발생하는 에러들을 해결하였습니다.
> - challengeSelectView에서 챌린지 목록 창에서 챌린지를 성취하였음에도 completed css가 적용되지 않는 문제를 해결하였습니다.
> - challengePlayView에서 챌린지 조회 로직이 tmInit 메서드보다 늦게 동작함에 따라 tmInit 운동 타입 파라미터 데이터가 null인 문제를 해결하였습니다.
> - challengePlayView router 파라미터인 challengeId 데이터가 null인 문제를 해결하였습니다.