### PR TITLE
챌린지 현재 성취 개수 반영

### DIFF
--- a/src/views/ChallengeSelectView.vue
+++ b/src/views/ChallengeSelectView.vue
@@ -67,6 +67,7 @@
                             <div class="challenge-info">{{ challenge.icon }} {{ challenge.type === 'PUSHUP' ? 'Push Up'
                                 : 'Squat' }}</div>
                             <div class="challenge-info">⏰ {{ challenge.endDt }}</div>
+                            <div class="challenge-info"> ⏳ 현재: {{ getTodayChallengeCnt(challenge.id) }} </div>
                             <div class="challenge-info">🎯 목표: {{ challenge.goalCnt }}</div>
                             <div class="progress-bar">
                                 <div class="progress-fill"
@@ -249,6 +250,13 @@ const startChallenge = () => {
         alert("챌린지를 선택해주세요.");
     }
 }
+
+const getTodayChallengeCnt = (challengeId) => {
+    const todayChallenge = todayChallengeStore.todayChallenges.find(
+        (tc) => tc.challengeId === challengeId
+    );
+    return todayChallenge ? todayChallenge.cnt : 0;
+};
 
 const toggleEdit = (index) => {
     const challenge = challenges.value[index];
@@ -588,8 +596,9 @@ onMounted(async () => {
 
 .challenge-info {
     font-size: 25px;
-    line-height: 3;
-    margin: 8px 0;
+    line-height: 2.4;
+    margin-top: 8px;
+    margin-bottom: 8px;
 }
 
 .challenge-box.selected {


### PR DESCRIPTION
## 연관된 이슈

> #79

## 작업 내용

> 챌린지 선택 화면에서 챌린지들의 현재 성취 개수를 알 수 없기 때문에 사용자가 해당 챌린지를 성취했는지 몇 개를 더하면 되는지 혼란스러운 상황이 발생합니다.
> 이를 해결하기 위해 현재 성취 개수를 반영하였습니다.

### 스크린샷 (선택)
![스크린샷 2024-11-25 112300](https://github.com/user-attachments/assets/db5a8191-a060-4099-834b-099b839a9a01)

## 리뷰 요구사항 (선택)